### PR TITLE
Use `.` because `source` is a bash-ism

### DIFF
--- a/internal/controller/nodeopupgrade_controller.go
+++ b/internal/controller/nodeopupgrade_controller.go
@@ -154,7 +154,7 @@ set -x -e
 		script += `get_version() {
     local file_path="$1"
     # shellcheck disable=SC1090
-    source "$file_path"
+    . "$file_path"
 
     echo "${KAIROS_VERSION}-${KAIROS_SOFTWARE_VERSION_PREFIX}${KAIROS_SOFTWARE_VERSION}"
 }


### PR DESCRIPTION
Originally reported here: https://cloud-native.slack.com/archives/C0707M8UEU8/p1756214459966169