### PR TITLE
Add KAIROS_OCI_IMAGE env to NodeOp job container spec

### DIFF
--- a/internal/controller/nodeop_controller.go
+++ b/internal/controller/nodeop_controller.go
@@ -336,6 +336,12 @@ func (r *NodeOpReconciler) createRebootJobSpec(nodeOp *kairosiov1alpha1.NodeOp, 
 						Name:    "nodeop",
 						Image:   nodeOp.Spec.Image,
 						Command: nodeOp.Spec.Command,
+						Env: []corev1.EnvVar{
+							{
+								Name:  "KAIROS_OCI_IMAGE",
+								Value: nodeOp.Spec.Image,
+							},
+						},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: asBool(true),
 						},
@@ -419,6 +425,12 @@ func (r *NodeOpReconciler) createStandardJobSpec(nodeOp *kairosiov1alpha1.NodeOp
 							{
 								Name:      "host-root",
 								MountPath: "/host",
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "KAIROS_OCI_IMAGE",
+								Value: nodeOp.Spec.Image,
 							},
 						},
 					},

--- a/internal/controller/nodeopupgrade_controller.go
+++ b/internal/controller/nodeopupgrade_controller.go
@@ -193,35 +193,40 @@ mount --rbind ` + hostMountPath + `/run /run
 
 	upgradeRecovery := getBool(nodeOpUpgrade.Spec.UpgradeRecovery, UpgradeRecoveryDefault)
 	upgradeActive := getBool(nodeOpUpgrade.Spec.UpgradeActive, UpgradeActiveDefault)
+	upgradeSource := "dir:/"
 
 	// Add upgrade logic based on spec
 	if upgradeRecovery && upgradeActive {
 		// Both recovery and active
-		script += `# Upgrade recovery partition
-kairos-agent upgrade --recovery --source dir:/
+		scriptTemplate := `# Upgrade recovery partition
+kairos-agent upgrade --recovery --source %s
 
 # Upgrade active partition
-kairos-agent upgrade --source dir:/
+kairos-agent upgrade --source %s
 exit 0
 `
+		script += fmt.Sprintf(scriptTemplate, upgradeSource, upgradeSource)
 	} else if upgradeRecovery {
 		// Recovery only
-		script += `# Upgrade recovery partition only
-kairos-agent upgrade --recovery --source dir:/
+		scriptTemplate := `# Upgrade recovery partition only
+kairos-agent upgrade --recovery --source %s
 exit 0
 `
+		script += fmt.Sprintf(scriptTemplate, upgradeSource)
 	} else if upgradeActive {
 		// Active only (default behavior)
-		script += `# Upgrade active partition
-kairos-agent upgrade --source dir:/
+		scriptTemplate := `# Upgrade active partition
+kairos-agent upgrade --source %s
 exit 0
 `
+		script += fmt.Sprintf(scriptTemplate, upgradeSource)
 	} else {
 		// Neither specified - default to active
-		script += `# Upgrade active partition (default)
-kairos-agent upgrade --source dir:/
+		scriptTemplate := `# Upgrade active partition (default)
+kairos-agent upgrade --source %s
 exit 0
 `
+		script += fmt.Sprintf(scriptTemplate, upgradeSource)
 	}
 
 	// Build the complete command

--- a/internal/controller/nodeopupgrade_controller.go
+++ b/internal/controller/nodeopupgrade_controller.go
@@ -193,7 +193,7 @@ mount --rbind ` + hostMountPath + `/run /run
 
 	upgradeRecovery := getBool(nodeOpUpgrade.Spec.UpgradeRecovery, UpgradeRecoveryDefault)
 	upgradeActive := getBool(nodeOpUpgrade.Spec.UpgradeActive, UpgradeActiveDefault)
-	upgradeSource := "dir:/"
+	upgradeSource := "\"oci:${KAIROS_OCI_IMAGE}\""
 
 	// Add upgrade logic based on spec
 	if upgradeRecovery && upgradeActive {

--- a/internal/controller/nodeopupgrade_controller_test.go
+++ b/internal/controller/nodeopupgrade_controller_test.go
@@ -237,7 +237,7 @@ var _ = Describe("NodeOpUpgrade Controller", func() {
 			Expect(nodeOp.Spec.Command[1]).To(Equal("-c"))
 
 			script := nodeOp.Spec.Command[2]
-			Expect(script).To(ContainSubstring("kairos-agent upgrade --source dir:/"))
+			Expect(script).To(ContainSubstring("kairos-agent upgrade --source \"oci:${KAIROS_OCI_IMAGE}\""))
 			Expect(script).To(ContainSubstring("get_version()"))
 			Expect(script).To(ContainSubstring("mount --rbind"))
 			Expect(script).NotTo(ContainSubstring("--recovery"))
@@ -274,7 +274,7 @@ var _ = Describe("NodeOpUpgrade Controller", func() {
 			}, nodeOp)).To(Succeed())
 
 			script := nodeOp.Spec.Command[2]
-			Expect(script).To(ContainSubstring("kairos-agent upgrade --recovery --source dir:/"))
+			Expect(script).To(ContainSubstring("kairos-agent upgrade --recovery --source \"oci:${KAIROS_OCI_IMAGE}\""))
 		})
 
 		It("should generate correct upgrade command for both partitions", func() {
@@ -308,9 +308,9 @@ var _ = Describe("NodeOpUpgrade Controller", func() {
 
 			script := nodeOp.Spec.Command[2]
 			Expect(script).To(ContainSubstring("# Upgrade recovery partition"))
-			Expect(script).To(ContainSubstring("kairos-agent upgrade --recovery --source dir:/"))
+			Expect(script).To(ContainSubstring("kairos-agent upgrade --recovery --source \"oci:${KAIROS_OCI_IMAGE}\""))
 			Expect(script).To(ContainSubstring("# Upgrade active partition"))
-			Expect(script).To(ContainSubstring("kairos-agent upgrade --source dir:/"))
+			Expect(script).To(ContainSubstring("kairos-agent upgrade --source \"oci:${KAIROS_OCI_IMAGE}\""))
 		})
 
 		It("should generate correct upgrade command with force enabled", func() {


### PR DESCRIPTION
I'm having trouble with the regular `NodeOpUpgrade` which overwrites  the `/etc/hosts` and `/etc/hostname` files from the initContainer to the host.

The issue is that those files are generated by Kubernetes and include references to the pod IP and name. When the node reboots after the upgrade, it fails to register into the cluster because of the changed hostname.

I've managed to work around the issue by using a `NodeOp` instead and manually changing its container command to use an OCI source instead of the pod's root FS.

Adding this envvar would allow to use it the command instead of hardcoding the image reference.