### PR TITLE
Fix string comparison in upgrade command

### DIFF
--- a/internal/controller/nodeopupgrade_controller.go
+++ b/internal/controller/nodeopupgrade_controller.go
@@ -145,8 +145,7 @@ func (r *NodeOpUpgradeReconciler) createNodeOp(ctx context.Context,
 
 // generateUpgradeCommand creates the upgrade command based on the NodeOpUpgrade specification
 func (r *NodeOpUpgradeReconciler) generateUpgradeCommand(nodeOpUpgrade *kairosiov1alpha1.NodeOpUpgrade) []string {
-	script := `#!/bin/bash
-set -x -e
+	script := `set -x -e
 
 `
 


### PR DESCRIPTION
We are setting up a kairos based k8s cluster and trying out the operator together with nodeopupgrade.
But the node was stuck in an infinite upgrade loop checking the logs of the `kairos-upgrade` pod we found the following in the logs
```
stderr F + KAIROS_VERSION=v4.7.3
stderr F + KAIROS_SOFTWARE_VERSION_PREFIX=kubeadm-provider
stderr F + KAIROS_SOFTWARE_VERSION=v1.0.0
stderr F + echo v4.7.3-kubeadm-providerv1.0.0
stderr F + CURRENT_VERSION=v4.7.3-kubeadm-providerv1.0.0
stderr F + [ v4.7.3-kubeadm-providerv1.0.0 == v4.7.3-kubeadm-providerv1.0.0 ]
stderr F /bin/sh: 27: [: v4.7.3-kubeadm-providerv1.0.0: unexpected operator
stderr F + mount --rbind /host/dev /dev
```

This causes the early exit to fail and the script continues with the upgrade.

As it's using sh the bash `==` operator does not exists and `=` should be used.
I am a bit confused as this code was already part of the codebase for a while and the issue has not surfaced before

