### PR TITLE
Support multiple architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM alpine:latest
+ARG TARGETARCH
 WORKDIR /
 # Install kubectl and other necessary tools
 RUN apk add --no-cache curl ca-certificates && \
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Secondary issue with our journey of setting up up a kairos based k8s cluster together with nodeopupgrade 😉 
The reboot node becomes stuck on arm64 devices, as part of the pipeline is cleaning up the sentinel file and then marking the pod as completed using kubectl patch. This patch however uses kubectl which is in the current dockerfile always amd64 based so it fails with the following error:
```
stdout F Deleting sentinel file before reboot...
stdout F Attempting to patch pod...
stderr F /usr/local/bin/kubectl: line 1: syntax error: unexpected "("
stdout F kubectl patch failed
```

By using the already available `TARGETARCH` the dockerfile is compatible with both architectures. The build process you have in place already builds for both architectures so I think this tiny PR already covers the necessary changes