### PR TITLE
Fix labeler jobs for nodes with readonly FS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
   "name": "Kubebuilder DevContainer",
   "image": "docker.io/golang:1.26",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": false
+    },
     "ghcr.io/devcontainers/features/git:1": {}
   },
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,14 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM alpine:latest
 ARG TARGETARCH
 WORKDIR /
+# Create a non-root user with numeric UID
+RUN adduser -D -u 65532 -s /bin/sh manager
 # Install kubectl and other necessary tools
 RUN apk add --no-cache curl ca-certificates && \
     curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/
 COPY --from=builder /workspace/manager .
-# Create a non-root user with numeric UID
-RUN adduser -D -u 65532 -s /bin/sh manager
-USER 65532:65532
 
+USER 65532:65532
 ENTRYPOINT ["/manager"]

--- a/internal/controller/nodelabeler_controller.go
+++ b/internal/controller/nodelabeler_controller.go
@@ -248,11 +248,12 @@ func (r *NodeLabelerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 func (r *NodeLabelerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	setupLog := logf.Log.WithName("setup")
+
 	// Ensure RBAC resources are created when the controller starts
 	namespace := r.getOperatorNamespace()
 	if err := r.ensureServiceAccount(context.Background(), namespace); err != nil {
-		log := logf.Log.WithName("setup")
-		log.Error(err, "Failed to ensure service account and RBAC")
+		setupLog.Error(err, "Failed to ensure service account and RBAC")
 		os.Exit(1)
 	}
 

--- a/internal/controller/nodelabeler_controller.go
+++ b/internal/controller/nodelabeler_controller.go
@@ -10,10 +10,13 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/kairos-io/kairos-operator/internal/utils"
 )
@@ -257,7 +260,28 @@ func (r *NodeLabelerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		os.Exit(1)
 	}
 
+	// Define selector for nodes that should be ignored
+	nodeSelector, err := labels.Parse("kairos.io/managed notin (false)")
+	if err != nil {
+		setupLog.Error(err, "Failed to parse label selector for nodes")
+		os.Exit(1)
+	}
+
+	log := logf.FromContext(context.TODO())
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Node{}).
+		For(
+			&corev1.Node{},
+			// Filter out ignored nodes
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				node := obj.(*corev1.Node)
+
+				matches := nodeSelector.Matches(labels.Set(node.ObjectMeta.Labels))
+				if !matches {
+					log.V(1).Info("Ignoring explicitly labeled node", "node", node.ObjectMeta.Name)
+				}
+
+				return matches
+			})),
+		).
 		Complete(r)
 }


### PR DESCRIPTION
Hello @kairos-io

When trying to use the operator in hybrid clusters using both Kairos and other immutable OS (namely Talos) nodes, pods created by the nodelabeler controller currently fail to start because kubelet fails to create the `/etc/kairos-release` file referenced in the Job's volumes on a read-only FS.

This PR adds a predicate in the controller setup to ignore nodes labeled with `kairos.io/managed=false`. 

I've also included :
* a fix for the DIND config for the devcontainer
* a small change in the order of `Dockerfile` layers to improve cache usage