### PR TITLE
Mount the whole `/etc` directory

### DIFF
--- a/cmd/node-labeler/main.go
+++ b/cmd/node-labeler/main.go
@@ -68,7 +68,7 @@ func main() {
 
 func checkKairosNode() (bool, error) {
 	// Check if kairos-release exists and has content
-	if content, err := os.ReadFile("/etc/kairos-release"); err == nil {
+	if content, err := os.ReadFile("/host/etc/kairos-release"); err == nil {
 		// Only consider it a Kairos node if the file has content
 		if len(content) > 0 {
 			fmt.Println("Kairos release file found with content")
@@ -77,7 +77,7 @@ func checkKairosNode() (bool, error) {
 	}
 
 	// Check os-release for Kairos
-	osRelease, err := os.ReadFile("/etc/os-release")
+	osRelease, err := os.ReadFile("/host/etc/os-release")
 	if err != nil {
 		return false, fmt.Errorf("error reading os-release: %v", err)
 	}

--- a/cmd/node-labeler/main.go
+++ b/cmd/node-labeler/main.go
@@ -87,6 +87,9 @@ func checkKairosNode() (bool, error) {
 	// Check os-release for Kairos
 	osRelease, err := os.ReadFile(etcPath + "/os-release")
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
 		return false, fmt.Errorf("error reading os-release: %v", err)
 	}
 

--- a/cmd/node-labeler/main.go
+++ b/cmd/node-labeler/main.go
@@ -66,9 +66,17 @@ func main() {
 	}
 }
 
+func hostEtcPath() string {
+	if p := os.Getenv("HOST_ETC_PATH"); p != "" {
+		return p
+	}
+	return "/host/etc"
+}
+
 func checkKairosNode() (bool, error) {
+	etcPath := hostEtcPath()
 	// Check if kairos-release exists and has content
-	if content, err := os.ReadFile("/host/etc/kairos-release"); err == nil {
+	if content, err := os.ReadFile(etcPath + "/kairos-release"); err == nil {
 		// Only consider it a Kairos node if the file has content
 		if len(content) > 0 {
 			fmt.Println("Kairos release file found with content")
@@ -77,7 +85,7 @@ func checkKairosNode() (bool, error) {
 	}
 
 	// Check os-release for Kairos
-	osRelease, err := os.ReadFile("/host/etc/os-release")
+	osRelease, err := os.ReadFile(etcPath + "/os-release")
 	if err != nil {
 		return false, fmt.Errorf("error reading os-release: %v", err)
 	}

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -12,6 +12,22 @@ patches:
   target:
     kind: Deployment
     name: kairos-operator
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: kairos-operator
+    spec:
+      template:
+        spec:
+          containers:
+          - name: manager
+            env:
+            - name: NODE_LABELER_IMAGE
+              value: controller-node-labeler:latest
+  target:
+    kind: Deployment
+    name: kairos-operator
 
 images:
 - name: controller

--- a/internal/controller/nodelabeler_controller.go
+++ b/internal/controller/nodelabeler_controller.go
@@ -111,6 +111,10 @@ func (r *NodeLabelerReconciler) createNodeLabelerJob(node *corev1.Node, namespac
 										},
 									},
 								},
+								{
+									Name:  "HOST_ETC_PATH",
+									Value: "/host/etc",
+								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/internal/controller/nodelabeler_controller.go
+++ b/internal/controller/nodelabeler_controller.go
@@ -114,13 +114,8 @@ func (r *NodeLabelerReconciler) createNodeLabelerJob(node *corev1.Node, namespac
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "kairos-release",
-									MountPath: "/etc/kairos-release",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "os-release",
-									MountPath: "/etc/os-release",
+									Name:      "host-etc",
+									MountPath: "/host/etc",
 									ReadOnly:  true,
 								},
 							},
@@ -128,18 +123,10 @@ func (r *NodeLabelerReconciler) createNodeLabelerJob(node *corev1.Node, namespac
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "kairos-release",
+							Name: "host-etc",
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/kairos-release",
-								},
-							},
-						},
-						{
-							Name: "os-release",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/os-release",
+									Path: "/etc",
 								},
 							},
 						},

--- a/internal/controller/nodelabeler_controller_test.go
+++ b/internal/controller/nodelabeler_controller_test.go
@@ -112,14 +112,15 @@ var _ = Describe("NodeLabeler Controller", func() {
 			Expect(*container.SecurityContext.RunAsUser).To(Equal(int64(1000)))
 
 			// Verify volume mounts
-			Expect(container.VolumeMounts).To(HaveLen(2))
-			Expect(container.VolumeMounts[0].Name).To(Equal("kairos-release"))
-			Expect(container.VolumeMounts[1].Name).To(Equal("os-release"))
+			Expect(container.VolumeMounts).To(HaveLen(1))
+			Expect(container.VolumeMounts[0].Name).To(Equal("host-etc"))
+			Expect(container.VolumeMounts[0].MountPath).To(Equal("/host/etc"))
+			Expect(container.VolumeMounts[0].ReadOnly).To(BeTrue())
 
 			// Verify volumes
-			Expect(foundJob.Spec.Template.Spec.Volumes).To(HaveLen(2))
-			Expect(foundJob.Spec.Template.Spec.Volumes[0].Name).To(Equal("kairos-release"))
-			Expect(foundJob.Spec.Template.Spec.Volumes[1].Name).To(Equal("os-release"))
+			Expect(foundJob.Spec.Template.Spec.Volumes).To(HaveLen(1))
+			Expect(foundJob.Spec.Template.Spec.Volumes[0].Name).To(Equal("host-etc"))
+			Expect(foundJob.Spec.Template.Spec.Volumes[0].HostPath.Path).To(Equal("/etc"))
 		})
 
 		It("should not create a new job if one already exists", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -544,23 +544,7 @@ func installOperator() {
 	out, err := cmd.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), string(out))
 
-	// Wait for initial rollout to complete (in case deployment already existed)
-	By("waiting for initial deployment rollout to complete")
-	initialRolloutCmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "rollout", "status",
-		"deployment/operator-kairos-operator", "-n", namespace, "--timeout=2m")
-	initialRolloutOut, err := initialRolloutCmd.CombinedOutput()
-	Expect(err).NotTo(HaveOccurred(), string(initialRolloutOut))
-
-	// Patch the node-labeler image environment variable to use the locally built image
-	// The default kustomization adds this env var, but we need to update it to use our local image
-	By("patching node-labeler image environment variable")
-	patchCmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "set", "env", "deployment",
-		"operator-kairos-operator", fmt.Sprintf("NODE_LABELER_IMAGE=%s", nodeLabelerImage), "-n", namespace)
-	patchOut, err := patchCmd.CombinedOutput()
-	Expect(err).NotTo(HaveOccurred(), string(patchOut))
-
-	// Wait for the rollout to complete after patching to ensure only one pod is running
-	By("waiting for deployment rollout to complete after patching")
+	By("waiting for deployment rollout to complete")
 	rolloutCmd := exec.Command("kubectl", "--kubeconfig", kubeconfig, "rollout", "status",
 		"deployment/operator-kairos-operator", "-n", namespace, "--timeout=2m")
 	rolloutOut, err := rolloutCmd.CombinedOutput()


### PR DESCRIPTION
because `/etc/kairos-release` doesn't exist in non-Kairos nodes and it will not allow the Pods to be even scheduled on read-only Nodes that don't have the file (because it can't be created).

See here for more:

https://github.com/kairos-io/kairos-operator/pull/74

Also part of this solution:

https://github.com/kairos-io/kairos/issues/3971#issuecomment-4281056270