### PR TITLE
Let the labeler run in a loop and create more labels and annotations

### DIFF
--- a/Dockerfile.node-labeler
+++ b/Dockerfile.node-labeler
@@ -21,7 +21,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o node-labeler cmd/node-labeler/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o node-labeler ./cmd/node-labeler/
 
 # Use distroless as minimal base image to package the node-labeler binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+NODE_LABELER_IMG ?= controller-node-labeler:latest
 CLUSTER_NAME ?= kairos-operator-e2e
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -112,6 +113,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
 
+.PHONY: docker-build-node-labeler
+docker-build-node-labeler: ## Build docker image for the node-labeler.
+	$(CONTAINER_TOOL) build -t ${NODE_LABELER_IMG} -f Dockerfile.node-labeler .
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
@@ -184,8 +189,9 @@ kind-setup: ## Create a kind cluster for testing
 	$(MAKE) kind-setup-image
 
 .PHONY: kind-setup-image
-kind-setup-image: docker-build ## Load the controller image into the kind cluster
+kind-setup-image: docker-build docker-build-node-labeler ## Load the controller and node-labeler images into the kind cluster
 	$(KIND) load docker-image --name $(CLUSTER_NAME) $(IMG)
+	$(KIND) load docker-image --name $(CLUSTER_NAME) $(NODE_LABELER_IMG)
 
 .PHONY: kind-teardown
 kind-teardown: ## Delete the kind cluster

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -210,6 +210,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controller.NodeLabelerDaemonSetReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "NodeLabelerDaemonSet")
+		os.Exit(1)
+	}
+
 	if err = (&controller.NodeOpUpgradeReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/cmd/node-labeler/labeler.go
+++ b/cmd/node-labeler/labeler.go
@@ -44,10 +44,7 @@ var annotationFields = map[string]string{
 // the resulting labels and annotations to the named node.
 // Returns nil without patching if the node is not a Kairos node.
 func syncLabels(ctx context.Context, clientset kubernetes.Interface, nodeName, etcPath, cmdlinePath string) error {
-	labels, annotations, err := collectMetadata(etcPath, cmdlinePath)
-	if err != nil {
-		return err
-	}
+	labels, annotations := collectMetadata(etcPath, cmdlinePath)
 
 	if len(labels) == 0 {
 		fmt.Printf("node %s is not a Kairos node, skipping\n", nodeName)
@@ -64,23 +61,23 @@ func syncLabels(ctx context.Context, clientset kubernetes.Interface, nodeName, e
 
 // collectMetadata parses kairos-release and /proc/cmdline and returns the labels
 // and annotations to apply. Returns empty maps (not an error) if not a Kairos node.
-func collectMetadata(etcPath, cmdlinePath string) (labels, annotations map[string]string, err error) {
+func collectMetadata(etcPath, cmdlinePath string) (labels, annotations map[string]string) {
 	release, err := parseEnvFile(etcPath + "/kairos-release")
 	if err != nil {
 		fmt.Printf("cannot read kairos-release, assuming non-Kairos node: %v\n", err)
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	if release == nil {
 		if !isKairosOSRelease(etcPath) {
-			return nil, nil, nil
+			return nil, nil
 		}
 		fmt.Println("Kairos ID found in os-release")
 		labels = map[string]string{"kairos.io/managed": "true"}
 		if bootState := detectBootState(cmdlinePath); bootState != "" {
 			labels["kairos.io/boot-state"] = bootState
 		}
-		return labels, map[string]string{}, nil
+		return labels, map[string]string{}
 	}
 
 	labels = map[string]string{"kairos.io/managed": "true"}
@@ -102,7 +99,7 @@ func collectMetadata(etcPath, cmdlinePath string) (labels, annotations map[strin
 		labels["kairos.io/boot-state"] = bootState
 	}
 
-	return labels, annotations, nil
+	return labels, annotations
 }
 
 // detectBootState reads cmdlinePath and returns the Kairos boot state label value
@@ -150,7 +147,7 @@ func parseEnvFile(path string) (map[string]string, error) {
 		}
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	result := make(map[string]string)
 	scanner := bufio.NewScanner(f)
@@ -190,7 +187,8 @@ type nodePatchMetadata struct {
 	Annotations map[string]*string `json:"annotations,omitempty"`
 }
 
-func patchNode(ctx context.Context, clientset kubernetes.Interface, nodeName string, labels, annotations map[string]string) error {
+func patchNode(ctx context.Context, clientset kubernetes.Interface, nodeName string,
+	labels, annotations map[string]string) error {
 	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("getting node %s: %w", nodeName, err)

--- a/cmd/node-labeler/labeler.go
+++ b/cmd/node-labeler/labeler.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// labelFields maps KAIROS_<KEY> suffixes from kairos-release to node label names.
+var labelFields = map[string]string{
+	"ID":                      "kairos.io/id",
+	"FAMILY":                  "kairos.io/family",
+	"FLAVOR":                  "kairos.io/flavor",
+	"FLAVOR_RELEASE":          "kairos.io/flavor-release",
+	"VARIANT":                 "kairos.io/variant",
+	"RELEASE":                 "kairos.io/release",
+	"MODEL":                   "kairos.io/model",
+	"ARCH":                    "kairos.io/arch",
+	"TRUSTED_BOOT":            "kairos.io/trusted-boot",
+	"FIPS":                    "kairos.io/fips",
+	"SOFTWARE_VERSION_PREFIX": "kairos.io/software-version-prefix",
+	"SOFTWARE_VERSION":        "kairos.io/software-version",
+}
+
+// annotationFields maps KAIROS_<KEY> suffixes to node annotation names.
+var annotationFields = map[string]string{
+	"NAME":           "kairos.io/name",
+	"ID_LIKE":        "kairos.io/id-like",
+	"INIT_VERSION":   "kairos.io/init-version",
+	"VERSION":        "kairos.io/version",
+	"BUG_REPORT_URL": "kairos.io/bug-report-url",
+	"HOME_URL":       "kairos.io/home-url",
+}
+
+// syncLabels reads Kairos metadata from etcPath and cmdlinePath and applies
+// the resulting labels and annotations to the named node.
+// Returns nil without patching if the node is not a Kairos node.
+func syncLabels(ctx context.Context, clientset kubernetes.Interface, nodeName, etcPath, cmdlinePath string) error {
+	labels, annotations, err := collectMetadata(etcPath, cmdlinePath)
+	if err != nil {
+		return err
+	}
+
+	if len(labels) == 0 {
+		fmt.Printf("node %s is not a Kairos node, skipping\n", nodeName)
+		return nil
+	}
+
+	if err := patchNode(ctx, clientset, nodeName, labels, annotations); err != nil {
+		return err
+	}
+
+	fmt.Printf("labeled node %s\n", nodeName)
+	return nil
+}
+
+// collectMetadata parses kairos-release and /proc/cmdline and returns the labels
+// and annotations to apply. Returns empty maps (not an error) if not a Kairos node.
+func collectMetadata(etcPath, cmdlinePath string) (labels, annotations map[string]string, err error) {
+	release, err := parseEnvFile(etcPath + "/kairos-release")
+	if err != nil {
+		fmt.Printf("cannot read kairos-release, assuming non-Kairos node: %v\n", err)
+		return nil, nil, nil
+	}
+
+	if release == nil {
+		if !isKairosOSRelease(etcPath) {
+			return nil, nil, nil
+		}
+		fmt.Println("Kairos ID found in os-release")
+		labels = map[string]string{"kairos.io/managed": "true"}
+		if bootState := detectBootState(cmdlinePath); bootState != "" {
+			labels["kairos.io/boot-state"] = bootState
+		}
+		return labels, map[string]string{}, nil
+	}
+
+	labels = map[string]string{"kairos.io/managed": "true"}
+	annotations = map[string]string{}
+
+	for key, labelName := range labelFields {
+		if v := release["KAIROS_"+key]; v != "" {
+			labels[labelName] = sanitizeLabelValue(v)
+		}
+	}
+
+	for key, annotationName := range annotationFields {
+		if v := release["KAIROS_"+key]; v != "" {
+			annotations[annotationName] = v
+		}
+	}
+
+	if bootState := detectBootState(cmdlinePath); bootState != "" {
+		labels["kairos.io/boot-state"] = bootState
+	}
+
+	return labels, annotations, nil
+}
+
+// detectBootState reads cmdlinePath and returns the Kairos boot state label value
+// (active, passive, recovery, livecd, or unknown).
+func detectBootState(cmdlinePath string) string {
+	data, err := os.ReadFile(cmdlinePath)
+	if err != nil {
+		return ""
+	}
+	cmdline := string(data)
+
+	switch {
+	case strings.Contains(cmdline, "COS_ACTIVE"):
+		return "active"
+	case strings.Contains(cmdline, "COS_PASSIVE"):
+		return "passive"
+	case strings.Contains(cmdline, "COS_RECOVERY"),
+		strings.Contains(cmdline, "COS_SYSTEM"),
+		strings.Contains(cmdline, "recovery-mode"):
+		return "recovery"
+	case strings.Contains(cmdline, "live:LABEL"),
+		strings.Contains(cmdline, "live:CDLABEL"),
+		strings.Contains(cmdline, "netboot"):
+		return "livecd"
+	default:
+		return "unknown"
+	}
+}
+
+func isKairosOSRelease(etcPath string) bool {
+	osRelease, err := parseEnvFile(etcPath + "/os-release")
+	if err != nil || osRelease == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(osRelease["ID"]), "kairos")
+}
+
+// parseEnvFile parses a KEY=VALUE or KEY="VALUE" env file into a map.
+// Returns nil (not an error) if the file does not exist.
+func parseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		result[k] = strings.Trim(v, `"'`)
+	}
+	return result, scanner.Err()
+}
+
+var invalidLabelChars = regexp.MustCompile(`[^a-zA-Z0-9\-_.]`)
+
+// sanitizeLabelValue makes s a valid Kubernetes label value by replacing
+// invalid characters with "-" and truncating to 63 characters.
+func sanitizeLabelValue(s string) string {
+	s = invalidLabelChars.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-_.")
+	if len(s) > 63 {
+		s = s[:63]
+	}
+	return s
+}
+
+type nodePatch struct {
+	Metadata nodePatchMetadata `json:"metadata"`
+}
+
+type nodePatchMetadata struct {
+	Labels      map[string]*string `json:"labels,omitempty"`
+	Annotations map[string]*string `json:"annotations,omitempty"`
+}
+
+func patchNode(ctx context.Context, clientset kubernetes.Interface, nodeName string, labels, annotations map[string]string) error {
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("getting node %s: %w", nodeName, err)
+	}
+
+	patchLabels := toNullablePatch(labels, node.Labels)
+	patchAnnotations := toNullablePatch(annotations, node.Annotations)
+
+	if len(patchLabels) == 0 && len(patchAnnotations) == 0 {
+		return nil
+	}
+
+	patch := nodePatch{
+		Metadata: nodePatchMetadata{
+			Labels:      patchLabels,
+			Annotations: patchAnnotations,
+		},
+	}
+
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshaling patch: %w", err)
+	}
+
+	_, err = clientset.CoreV1().Nodes().Patch(
+		ctx,
+		nodeName,
+		types.MergePatchType,
+		data,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patching node %s: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+// toNullablePatch builds a map[string]*string that sets all values from newValues
+// and nullifies any existing kairos.io/* key absent from newValues, removing stale entries.
+func toNullablePatch(newValues, existing map[string]string) map[string]*string {
+	result := make(map[string]*string, len(newValues))
+	for k, v := range newValues {
+		result[k] = &v
+	}
+	for k := range existing {
+		if strings.HasPrefix(k, "kairos.io/") {
+			if _, present := newValues[k]; !present {
+				result[k] = nil
+			}
+		}
+	}
+	return result
+}

--- a/cmd/node-labeler/labeler.go
+++ b/cmd/node-labeler/labeler.go
@@ -173,7 +173,7 @@ func sanitizeLabelValue(s string) string {
 	s = invalidLabelChars.ReplaceAllString(s, "-")
 	s = strings.Trim(s, "-_.")
 	if len(s) > 63 {
-		s = s[:63]
+		s = strings.Trim(s[:63], "-_.")
 	}
 	return s
 }

--- a/cmd/node-labeler/labeler_test.go
+++ b/cmd/node-labeler/labeler_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const sampleKairosRelease = `KAIROS_ARCH="amd64"
+KAIROS_BUG_REPORT_URL="https://github.com/kairos-io/kairos/issues"
+KAIROS_FAMILY="hadron"
+KAIROS_FIPS="false"
+KAIROS_FLAVOR="hadron"
+KAIROS_FLAVOR_RELEASE="v0.0.4"
+KAIROS_HOME_URL="https://github.com/kairos-io/kairos"
+KAIROS_ID="kairos"
+KAIROS_ID_LIKE="kairos-core-hadron-v0.0.4"
+KAIROS_INIT_VERSION="v0.8.4"
+KAIROS_MODEL="generic"
+KAIROS_NAME="kairos-core-hadron-v0.0.4"
+KAIROS_RELEASE="v4.0.3"
+KAIROS_SOFTWARE_VERSION="v1.32.4+k3s1"
+KAIROS_SOFTWARE_VERSION_PREFIX="k3s"
+KAIROS_TARGETARCH="amd64"
+KAIROS_TRUSTED_BOOT="false"
+KAIROS_VARIANT="core"
+KAIROS_VERSION="v4.0.3"
+`
+
+func writeKairosRelease(content string) string {
+	dir := GinkgoT().TempDir()
+	if content != "" {
+		Expect(os.WriteFile(filepath.Join(dir, "kairos-release"), []byte(content), 0644)).To(Succeed())
+	}
+	return dir
+}
+
+func writeCmdlineFile(content string) string {
+	dir := GinkgoT().TempDir()
+	path := filepath.Join(dir, "cmdline")
+	Expect(os.WriteFile(path, []byte(content), 0644)).To(Succeed())
+	return path
+}
+
+func newNode(name string, labels, annotations map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+}
+
+var _ = Describe("Node Labeler", func() {
+
+	Describe("collectMetadata", func() {
+		Context("with a Kairos node", func() {
+			It("returns the expected labels", func() {
+				etcDir := writeKairosRelease(sampleKairosRelease)
+				cmdlinePath := writeCmdlineFile("BOOT_IMAGE=/boot/vmlinuz COS_ACTIVE root=LABEL=COS_ACTIVE")
+
+				labels, _, err := collectMetadata(etcDir, cmdlinePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(labels).To(HaveKeyWithValue("kairos.io/managed", "true"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/id", "kairos"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/family", "hadron"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/flavor", "hadron"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/flavor-release", "v0.0.4"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/variant", "core"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/release", "v4.0.3"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/model", "generic"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/arch", "amd64"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/trusted-boot", "false"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/fips", "false"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/software-version-prefix", "k3s"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/software-version", "v1.32.4-k3s1"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/boot-state", "active"))
+				Expect(labels).NotTo(HaveKey("kairos.io/targetarch"))
+			})
+
+			It("returns the expected annotations", func() {
+				etcDir := writeKairosRelease(sampleKairosRelease)
+				cmdlinePath := writeCmdlineFile("COS_ACTIVE")
+
+				_, annotations, err := collectMetadata(etcDir, cmdlinePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(annotations).To(HaveKeyWithValue("kairos.io/name", "kairos-core-hadron-v0.0.4"))
+				Expect(annotations).To(HaveKeyWithValue("kairos.io/id-like", "kairos-core-hadron-v0.0.4"))
+				Expect(annotations).To(HaveKeyWithValue("kairos.io/init-version", "v0.8.4"))
+				Expect(annotations).To(HaveKeyWithValue("kairos.io/version", "v4.0.3"))
+				Expect(annotations).To(HaveKeyWithValue("kairos.io/bug-report-url", "https://github.com/kairos-io/kairos/issues"))
+				Expect(annotations).To(HaveKeyWithValue("kairos.io/home-url", "https://github.com/kairos-io/kairos"))
+			})
+		})
+
+		Context("with an older Kairos node (os-release only, no kairos-release)", func() {
+			It("returns managed=true and boot-state from os-release", func() {
+				dir := GinkgoT().TempDir()
+				Expect(os.WriteFile(filepath.Join(dir, "os-release"), []byte("ID=kairos\nNAME=\"Kairos Legacy\"\n"), 0644)).To(Succeed())
+				cmdlinePath := writeCmdlineFile("COS_ACTIVE")
+
+				labels, annotations, err := collectMetadata(dir, cmdlinePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(labels).To(HaveKeyWithValue("kairos.io/managed", "true"))
+				Expect(labels).To(HaveKeyWithValue("kairos.io/boot-state", "active"))
+				Expect(annotations).To(BeEmpty())
+			})
+		})
+
+		Context("with a non-Kairos node", func() {
+			It("returns empty maps when kairos-release is absent", func() {
+				etcDir := writeKairosRelease("")
+				cmdlinePath := writeCmdlineFile("root=/dev/sda1")
+
+				labels, annotations, err := collectMetadata(etcDir, cmdlinePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(labels).To(BeEmpty())
+				Expect(annotations).To(BeEmpty())
+			})
+		})
+
+		DescribeTable("boot state detection",
+			func(cmdline, expectedState string) {
+				etcDir := writeKairosRelease(sampleKairosRelease)
+				cmdlinePath := writeCmdlineFile(cmdline)
+
+				labels, _, err := collectMetadata(etcDir, cmdlinePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(labels).To(HaveKeyWithValue("kairos.io/boot-state", expectedState))
+			},
+			Entry("active boot", "BOOT_IMAGE=/vmlinuz COS_ACTIVE root=LABEL=COS_ACTIVE", "active"),
+			Entry("passive boot", "BOOT_IMAGE=/vmlinuz COS_PASSIVE root=LABEL=COS_PASSIVE", "passive"),
+			Entry("recovery via COS_RECOVERY", "COS_RECOVERY", "recovery"),
+			Entry("recovery via recovery-mode", "recovery-mode", "recovery"),
+			Entry("livecd via live:LABEL", "live:LABEL=KAIROS_LIVE", "livecd"),
+			Entry("livecd via netboot", "netboot ip=dhcp", "livecd"),
+			Entry("unknown", "BOOT_IMAGE=/vmlinuz root=/dev/sda1", "unknown"),
+		)
+	})
+
+	Describe("syncLabels", func() {
+		Context("when metadata changes after an upgrade", func() {
+			It("removes stale labels no longer present in kairos-release", func() {
+				By("Setting up a node with an old label")
+				node := newNode("test-node", map[string]string{
+					"kairos.io/managed": "true",
+					"kairos.io/family":  "old-family",
+					"kairos.io/flavor":  "old-flavor",
+					"other.io/label":    "keep-me",
+				}, nil)
+				clientset := fake.NewSimpleClientset(node)
+
+				releaseWithoutFamily := `KAIROS_ID="kairos"
+KAIROS_FLAVOR="new-flavor"
+KAIROS_VARIANT="core"
+KAIROS_RELEASE="v5.0.0"
+KAIROS_MODEL="generic"
+KAIROS_TRUSTED_BOOT="false"
+KAIROS_FIPS="false"
+`
+				etcDir := writeKairosRelease(releaseWithoutFamily)
+				cmdlinePath := writeCmdlineFile("COS_ACTIVE")
+
+				By("Syncing labels with the new kairos-release")
+				Expect(syncLabels(context.Background(), clientset, "test-node", etcDir, cmdlinePath)).To(Succeed())
+
+				updated, err := clientset.CoreV1().Nodes().Get(context.Background(), "test-node", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(updated.Labels).NotTo(HaveKey("kairos.io/family"))
+				Expect(updated.Labels).To(HaveKeyWithValue("kairos.io/flavor", "new-flavor"))
+				Expect(updated.Labels).To(HaveKeyWithValue("other.io/label", "keep-me"))
+			})
+
+			It("removes stale annotations no longer present in kairos-release", func() {
+				By("Setting up a node with old annotations")
+				node := newNode("test-node", nil, map[string]string{
+					"kairos.io/init-version": "v0.7.0",
+					"kairos.io/name":         "old-name",
+					"other.io/annotation":    "keep-me",
+				})
+				clientset := fake.NewSimpleClientset(node)
+
+				releaseWithoutInit := `KAIROS_ID="kairos"
+KAIROS_FLAVOR="ubuntu"
+KAIROS_VARIANT="core"
+KAIROS_RELEASE="v5.0.0"
+KAIROS_MODEL="generic"
+KAIROS_TRUSTED_BOOT="false"
+KAIROS_FIPS="false"
+`
+				etcDir := writeKairosRelease(releaseWithoutInit)
+				cmdlinePath := writeCmdlineFile("COS_ACTIVE")
+
+				By("Syncing labels with the new kairos-release")
+				Expect(syncLabels(context.Background(), clientset, "test-node", etcDir, cmdlinePath)).To(Succeed())
+
+				updated, err := clientset.CoreV1().Nodes().Get(context.Background(), "test-node", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(updated.Annotations).NotTo(HaveKey("kairos.io/init-version"))
+				Expect(updated.Annotations).NotTo(HaveKey("kairos.io/name"))
+				Expect(updated.Annotations).To(HaveKeyWithValue("other.io/annotation", "keep-me"))
+			})
+		})
+
+		Context("with a non-Kairos node", func() {
+			It("does not touch the node", func() {
+				node := newNode("test-node", map[string]string{"existing": "label"}, nil)
+				clientset := fake.NewSimpleClientset(node)
+
+				etcDir := writeKairosRelease("")
+				cmdlinePath := writeCmdlineFile("root=/dev/sda1")
+
+				Expect(syncLabels(context.Background(), clientset, "test-node", etcDir, cmdlinePath)).To(Succeed())
+
+				updated, err := clientset.CoreV1().Nodes().Get(context.Background(), "test-node", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Labels).To(HaveKeyWithValue("existing", "label"))
+				Expect(updated.Labels).NotTo(HaveKey("kairos.io/managed"))
+			})
+		})
+	})
+
+	DescribeTable("sanitizeLabelValue",
+		func(input, want string) {
+			got := sanitizeLabelValue(input)
+			Expect(got).To(Equal(want))
+			Expect(len(got)).To(BeNumerically("<=", 63))
+		},
+		Entry("sanitizes + in version strings", "v1.32.4+k3s1", "v1.32.4-k3s1"),
+		Entry("leaves valid values unchanged", "v4.0.3", "v4.0.3"),
+		Entry("leaves hyphens and dots unchanged", "ubuntu-24.04", "ubuntu-24.04"),
+		Entry("trims leading dash", "-leading-dash", "leading-dash"),
+		Entry("trims trailing dot", "trailing-dot.", "trailing-dot"),
+		Entry("truncates to 63 characters", strings.Repeat("a", 70), strings.Repeat("a", 63)),
+		Entry("sanitizes all-invalid characters to empty string", strings.Repeat("+", 10), ""),
+	)
+})

--- a/cmd/node-labeler/labeler_test.go
+++ b/cmd/node-labeler/labeler_test.go
@@ -237,6 +237,7 @@ KAIROS_FIPS="false"
 		Entry("trims leading dash", "-leading-dash", "leading-dash"),
 		Entry("trims trailing dot", "trailing-dot.", "trailing-dot"),
 		Entry("truncates to 63 characters", strings.Repeat("a", 70), strings.Repeat("a", 63)),
+		Entry("truncation does not leave trailing hyphen", strings.Repeat("a", 62)+"-a", strings.Repeat("a", 62)),
 		Entry("sanitizes all-invalid characters to empty string", strings.Repeat("+", 10), ""),
 	)
 })

--- a/cmd/node-labeler/labeler_test.go
+++ b/cmd/node-labeler/labeler_test.go
@@ -67,8 +67,7 @@ var _ = Describe("Node Labeler", func() {
 				etcDir := writeKairosRelease(sampleKairosRelease)
 				cmdlinePath := writeCmdlineFile("BOOT_IMAGE=/boot/vmlinuz COS_ACTIVE root=LABEL=COS_ACTIVE")
 
-				labels, _, err := collectMetadata(etcDir, cmdlinePath)
-				Expect(err).NotTo(HaveOccurred())
+				labels, _ := collectMetadata(etcDir, cmdlinePath)
 				Expect(labels).To(HaveKeyWithValue("kairos.io/managed", "true"))
 				Expect(labels).To(HaveKeyWithValue("kairos.io/id", "kairos"))
 				Expect(labels).To(HaveKeyWithValue("kairos.io/family", "hadron"))
@@ -90,8 +89,7 @@ var _ = Describe("Node Labeler", func() {
 				etcDir := writeKairosRelease(sampleKairosRelease)
 				cmdlinePath := writeCmdlineFile("COS_ACTIVE")
 
-				_, annotations, err := collectMetadata(etcDir, cmdlinePath)
-				Expect(err).NotTo(HaveOccurred())
+				_, annotations := collectMetadata(etcDir, cmdlinePath)
 				Expect(annotations).To(HaveKeyWithValue("kairos.io/name", "kairos-core-hadron-v0.0.4"))
 				Expect(annotations).To(HaveKeyWithValue("kairos.io/id-like", "kairos-core-hadron-v0.0.4"))
 				Expect(annotations).To(HaveKeyWithValue("kairos.io/init-version", "v0.8.4"))
@@ -107,8 +105,7 @@ var _ = Describe("Node Labeler", func() {
 				Expect(os.WriteFile(filepath.Join(dir, "os-release"), []byte("ID=kairos\nNAME=\"Kairos Legacy\"\n"), 0644)).To(Succeed())
 				cmdlinePath := writeCmdlineFile("COS_ACTIVE")
 
-				labels, annotations, err := collectMetadata(dir, cmdlinePath)
-				Expect(err).NotTo(HaveOccurred())
+				labels, annotations := collectMetadata(dir, cmdlinePath)
 				Expect(labels).To(HaveKeyWithValue("kairos.io/managed", "true"))
 				Expect(labels).To(HaveKeyWithValue("kairos.io/boot-state", "active"))
 				Expect(annotations).To(BeEmpty())
@@ -120,8 +117,7 @@ var _ = Describe("Node Labeler", func() {
 				etcDir := writeKairosRelease("")
 				cmdlinePath := writeCmdlineFile("root=/dev/sda1")
 
-				labels, annotations, err := collectMetadata(etcDir, cmdlinePath)
-				Expect(err).NotTo(HaveOccurred())
+				labels, annotations := collectMetadata(etcDir, cmdlinePath)
 				Expect(labels).To(BeEmpty())
 				Expect(annotations).To(BeEmpty())
 			})
@@ -132,8 +128,7 @@ var _ = Describe("Node Labeler", func() {
 				etcDir := writeKairosRelease(sampleKairosRelease)
 				cmdlinePath := writeCmdlineFile(cmdline)
 
-				labels, _, err := collectMetadata(etcDir, cmdlinePath)
-				Expect(err).NotTo(HaveOccurred())
+				labels, _ := collectMetadata(etcDir, cmdlinePath)
 				Expect(labels).To(HaveKeyWithValue("kairos.io/boot-state", expectedState))
 			},
 			Entry("active boot", "BOOT_IMAGE=/vmlinuz COS_ACTIVE root=LABEL=COS_ACTIVE", "active"),

--- a/cmd/node-labeler/main.go
+++ b/cmd/node-labeler/main.go
@@ -33,6 +33,8 @@ func main() {
 	defer cancel()
 
 	if *every > 0 {
+		ticker := time.NewTicker(time.Duration(*every) * time.Second)
+		defer ticker.Stop()
 		for {
 			if err := syncLabels(ctx, clientset, nodeName, hostEtcPath(), "/proc/cmdline"); err != nil && ctx.Err() == nil {
 				fmt.Fprintf(os.Stderr, "error syncing labels: %v\n", err)
@@ -40,7 +42,7 @@ func main() {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(time.Duration(*every) * time.Second):
+			case <-ticker.C:
 			}
 		}
 	} else {

--- a/cmd/node-labeler/main.go
+++ b/cmd/node-labeler/main.go
@@ -2,67 +2,52 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
-	"strings"
+	"os/signal"
+	"syscall"
+	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 func main() {
-	// Get node name from environment variable
+	every := flag.Int("every", 0, "re-label every N seconds; 0 runs once and exits")
+	flag.Parse()
+
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
-		fmt.Println("NODE_NAME environment variable is required")
+		fmt.Fprintln(os.Stderr, "NODE_NAME environment variable is required")
 		os.Exit(1)
 	}
 
-	// Create the in-cluster config
-	config, err := rest.InClusterConfig()
+	clientset, err := buildClientset()
 	if err != nil {
-		fmt.Printf("Error creating in-cluster config: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error building clientset: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Create the clientset
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		fmt.Printf("Error creating clientset: %v\n", err)
-		os.Exit(1)
-	}
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer cancel()
 
-	// Get the node
-	node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-	if err != nil {
-		fmt.Printf("Error getting node %s: %v\n", nodeName, err)
-		os.Exit(1)
-	}
-
-	// Check if it's a Kairos node
-	isKairos, err := checkKairosNode()
-	if err != nil {
-		fmt.Printf("Error checking if node is Kairos: %v\n", err)
-		os.Exit(1)
-	}
-
-	if isKairos {
-		// Label the node
-		if node.Labels == nil {
-			node.Labels = make(map[string]string)
+	if *every > 0 {
+		for {
+			if err := syncLabels(ctx, clientset, nodeName, hostEtcPath(), "/proc/cmdline"); err != nil && ctx.Err() == nil {
+				fmt.Fprintf(os.Stderr, "error syncing labels: %v\n", err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Duration(*every) * time.Second):
+			}
 		}
-		node.Labels["kairos.io/managed"] = "true"
-
-		// Update the node
-		_, err = clientset.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
-		if err != nil {
-			fmt.Printf("Error updating node %s: %v\n", nodeName, err)
+	} else {
+		if err := syncLabels(ctx, clientset, nodeName, hostEtcPath(), "/proc/cmdline"); err != nil {
+			fmt.Fprintf(os.Stderr, "error syncing labels: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("Successfully labeled node %s as kairos.io/managed=true\n", nodeName)
-	} else {
-		fmt.Printf("Node %s is not a Kairos node\n", nodeName)
 	}
 }
 
@@ -73,38 +58,10 @@ func hostEtcPath() string {
 	return "/host/etc"
 }
 
-func checkKairosNode() (bool, error) {
-	etcPath := hostEtcPath()
-	// Check if kairos-release exists and has content
-	if content, err := os.ReadFile(etcPath + "/kairos-release"); err == nil {
-		// Only consider it a Kairos node if the file has content
-		if len(content) > 0 {
-			fmt.Println("Kairos release file found with content")
-			return true, nil
-		}
-	}
-
-	// Check os-release for Kairos
-	osRelease, err := os.ReadFile(etcPath + "/os-release")
+func buildClientset() (kubernetes.Interface, error) {
+	config, err := rest.InClusterConfig()
 	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("error reading os-release: %v", err)
+		return nil, err
 	}
-
-	// Check if it's a Kairos node by looking for Kairos in the ID field
-	lines := strings.Split(string(osRelease), "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "ID=") {
-			id := strings.TrimPrefix(line, "ID=")
-			id = strings.Trim(id, "\"")
-			if strings.Contains(strings.ToLower(id), "kairos") {
-				fmt.Println("Kairos ID found in os-release")
-				return true, nil
-			}
-		}
-	}
-
-	return false, nil
+	return kubernetes.NewForConfig(config)
 }

--- a/cmd/node-labeler/suite_test.go
+++ b/cmd/node-labeler/suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNodeLabeler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Labeler Suite")
+}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -65,6 +65,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/internal/controller/nodelabeler_controller.go
+++ b/internal/controller/nodelabeler_controller.go
@@ -41,11 +41,9 @@ type NodeLabelerReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 
-func (r *NodeLabelerReconciler) getOperatorNamespace() string {
-	// Get namespace from environment variable
+func getOperatorNamespace() string {
 	namespace := os.Getenv("CONTROLLER_POD_NAMESPACE")
 	if namespace == "" {
-		// Fallback to "system" if not set
 		return "system"
 	}
 	return namespace
@@ -215,7 +213,7 @@ func (r *NodeLabelerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// Get the operator namespace
-	namespace := r.getOperatorNamespace()
+	namespace := getOperatorNamespace()
 
 	// Check if a labeler job already exists for this node
 	exists, err := r.jobExists(ctx, namespace, node.Name)
@@ -245,7 +243,7 @@ func (r *NodeLabelerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	setupLog := logf.Log.WithName("setup")
 
 	// Ensure RBAC resources are created when the controller starts
-	namespace := r.getOperatorNamespace()
+	namespace := getOperatorNamespace()
 	if err := r.ensureServiceAccount(context.Background(), namespace); err != nil {
 		setupLog.Error(err, "Failed to ensure service account and RBAC")
 		os.Exit(1)

--- a/internal/controller/nodelabeler_controller_test.go
+++ b/internal/controller/nodelabeler_controller_test.go
@@ -106,6 +106,9 @@ var _ = Describe("NodeLabeler Controller", func() {
 			Expect(container.Image).To(Equal("quay.io/kairos/operator-node-labeler:v0.0.1"))
 			Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 
+			// Verify one-off mode: no --every flag means the labeler runs once and exits
+			Expect(container.Args).To(BeEmpty())
+
 			// Verify security context
 			Expect(container.SecurityContext).NotTo(BeNil())
 			Expect(*container.SecurityContext.RunAsNonRoot).To(BeTrue())

--- a/internal/controller/nodelabeler_daemonset_controller.go
+++ b/internal/controller/nodelabeler_daemonset_controller.go
@@ -1,0 +1,144 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	kairosNodeLabelerDaemonSetName = "kairos-node-labeler"
+	defaultSyncIntervalSeconds     = 60
+)
+
+// NodeLabelerDaemonSetReconciler ensures a DaemonSet runs the node-labeler in
+// loop mode on every Kairos node, keeping labels in sync after upgrades.
+type NodeLabelerDaemonSetReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
+
+func (r *NodeLabelerDaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	namespace := getOperatorNamespace()
+	if req.Name != kairosNodeLabelerDaemonSetName || req.Namespace != namespace {
+		return ctrl.Result{}, nil
+	}
+
+	existing := &appsv1.DaemonSet{}
+	err := r.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, existing)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		ds := r.buildDaemonSet(namespace)
+		if err := r.Create(ctx, ds); err != nil {
+			log.Error(err, "Failed to create node-labeler DaemonSet")
+			return ctrl.Result{}, err
+		}
+		log.Info("Created node-labeler DaemonSet")
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NodeLabelerDaemonSetReconciler) buildDaemonSet(namespace string) *appsv1.DaemonSet {
+	nodeLabelerImage := os.Getenv("NODE_LABELER_IMAGE")
+	if nodeLabelerImage == "" {
+		nodeLabelerImage = "quay.io/kairos/operator-node-labeler:v0.0.1"
+	}
+
+	podLabels := map[string]string{
+		"app":  "kairos-node-labeler",
+		"mode": "daemon",
+	}
+
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kairosNodeLabelerDaemonSetName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "kairos-node-labeler",
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: nodeLabelerServiceAccount,
+					NodeSelector: map[string]string{
+						"kairos.io/managed": "true",
+					},
+					Tolerations: []corev1.Toleration{
+						{Operator: corev1.TolerationOpExists},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "node-labeler",
+							Image:           nodeLabelerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args:            []string{"--every", strconv.Itoa(defaultSyncIntervalSeconds)},
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: asBool(true),
+								RunAsUser:    &[]int64{1000}[0],
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											APIVersion: "v1",
+											FieldPath:  "spec.nodeName",
+										},
+									},
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "host-etc",
+									MountPath: "/host/etc",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "host-etc",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/etc",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *NodeLabelerDaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.DaemonSet{}).
+		Complete(r)
+}

--- a/internal/controller/nodelabeler_daemonset_controller.go
+++ b/internal/controller/nodelabeler_daemonset_controller.go
@@ -22,7 +22,22 @@ const (
 )
 
 // NodeLabelerDaemonSetReconciler ensures a DaemonSet runs the node-labeler in
-// loop mode on every Kairos node, keeping labels in sync after upgrades.
+// loop mode on every already-managed Kairos node, keeping labels and annotations
+// in sync across upgrades.
+//
+// Labeling lifecycle:
+//  1. NodeLabelerReconciler watches Node objects and creates a one-shot Job for
+//     each new node. That Job runs the node-labeler binary without --every,
+//     which sets kairos.io/managed=true (plus all other metadata labels).
+//  2. This DaemonSet — which selects on kairos.io/managed=true — then schedules
+//     a pod on that node and re-syncs labels on the configured interval.
+//
+// There is intentionally no chicken-and-egg problem: the DaemonSet only needs
+// to reach nodes that are already labeled, so it is correct and by design that
+// it won't run on a unlabeled node. The purpose of the Job is to identify Kairos
+// nodes once. The purpose of the DaemonSet is to keep a Pod running on each Kairos
+// node (and only Kairos nodes) to keep the labels and annotations in sync.
+// This way, we avoid running a "permanent" Pod on non-Kairos Nodes.
 type NodeLabelerDaemonSetReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme

--- a/internal/controller/nodelabeler_daemonset_controller.go
+++ b/internal/controller/nodelabeler_daemonset_controller.go
@@ -31,29 +31,41 @@ type NodeLabelerDaemonSetReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *NodeLabelerDaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := logf.FromContext(ctx)
-
 	namespace := getOperatorNamespace()
 	if req.Name != kairosNodeLabelerDaemonSetName || req.Namespace != namespace {
 		return ctrl.Result{}, nil
 	}
+	return ctrl.Result{}, r.ensureDaemonSet(ctx, namespace)
+}
 
+// ensureDaemonSetOnStartup is called from SetupWithManager before the cache is
+// started, so it must not read through the cache. It blindly attempts Create
+// and treats AlreadyExists as success.
+func (r *NodeLabelerDaemonSetReconciler) ensureDaemonSetOnStartup(ctx context.Context, namespace string) error {
+	if err := r.Create(ctx, r.buildDaemonSet(namespace)); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// ensureDaemonSet is safe to call from Reconcile (cache is running). It checks
+// first and only creates when the DaemonSet is genuinely absent.
+func (r *NodeLabelerDaemonSetReconciler) ensureDaemonSet(ctx context.Context, namespace string) error {
+	log := logf.FromContext(ctx)
 	existing := &appsv1.DaemonSet{}
 	err := r.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, existing)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, err
-		}
-		ds := r.buildDaemonSet(namespace)
-		if err := r.Create(ctx, ds); err != nil {
-			log.Error(err, "Failed to create node-labeler DaemonSet")
-			return ctrl.Result{}, err
-		}
-		log.Info("Created node-labeler DaemonSet")
-		return ctrl.Result{}, nil
+	if err == nil {
+		return nil
 	}
-
-	return ctrl.Result{}, nil
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+	if err := r.Create(ctx, r.buildDaemonSet(namespace)); err != nil {
+		log.Error(err, "Failed to create node-labeler DaemonSet")
+		return err
+	}
+	log.Info("Created node-labeler DaemonSet")
+	return nil
 }
 
 func (r *NodeLabelerDaemonSetReconciler) buildDaemonSet(namespace string) *appsv1.DaemonSet {
@@ -138,6 +150,11 @@ func (r *NodeLabelerDaemonSetReconciler) buildDaemonSet(namespace string) *appsv
 }
 
 func (r *NodeLabelerDaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	namespace := getOperatorNamespace()
+	if err := r.ensureDaemonSetOnStartup(context.Background(), namespace); err != nil {
+		log := logf.Log.WithName("setup")
+		log.Error(err, "Failed to ensure node-labeler DaemonSet")
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.DaemonSet{}).
 		Complete(r)

--- a/internal/controller/nodelabeler_daemonset_controller.go
+++ b/internal/controller/nodelabeler_daemonset_controller.go
@@ -13,8 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 const (
@@ -47,11 +49,7 @@ type NodeLabelerDaemonSetReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *NodeLabelerDaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	namespace := getOperatorNamespace()
-	if req.Name != kairosNodeLabelerDaemonSetName || req.Namespace != namespace {
-		return ctrl.Result{}, nil
-	}
-	return ctrl.Result{}, r.ensureDaemonSet(ctx, namespace)
+	return ctrl.Result{}, r.ensureDaemonSet(ctx, req.Namespace)
 }
 
 // ensureDaemonSetOnStartup is called from SetupWithManager before the cache is
@@ -182,6 +180,8 @@ func (r *NodeLabelerDaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		return fmt.Errorf("ensuring node-labeler DaemonSet: %w", err)
 	}
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appsv1.DaemonSet{}).
+		For(&appsv1.DaemonSet{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			return obj.GetName() == kairosNodeLabelerDaemonSetName && obj.GetNamespace() == namespace
+		}))).
 		Complete(r)
 }

--- a/internal/controller/nodelabeler_daemonset_controller.go
+++ b/internal/controller/nodelabeler_daemonset_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -178,8 +179,7 @@ func (r *NodeLabelerDaemonSetReconciler) buildDaemonSet(namespace string) *appsv
 func (r *NodeLabelerDaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	namespace := getOperatorNamespace()
 	if err := r.ensureDaemonSetOnStartup(context.Background(), namespace); err != nil {
-		log := logf.Log.WithName("setup")
-		log.Error(err, "Failed to ensure node-labeler DaemonSet")
+		return fmt.Errorf("ensuring node-labeler DaemonSet: %w", err)
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.DaemonSet{}).

--- a/internal/controller/nodelabeler_daemonset_controller.go
+++ b/internal/controller/nodelabeler_daemonset_controller.go
@@ -54,11 +54,22 @@ func (r *NodeLabelerDaemonSetReconciler) Reconcile(ctx context.Context, req ctrl
 }
 
 // ensureDaemonSetOnStartup is called from SetupWithManager before the cache is
-// started, so it must not read through the cache. It blindly attempts Create
-// and treats AlreadyExists as success.
+// started, so it must not read through the cache. On first install it creates
+// the DaemonSet; on subsequent operator startups (e.g. upgrades) it patches the
+// spec so that a new NODE_LABELER_IMAGE is rolled out without manual intervention.
 func (r *NodeLabelerDaemonSetReconciler) ensureDaemonSetOnStartup(ctx context.Context, namespace string) error {
-	if err := r.Create(ctx, r.buildDaemonSet(namespace)); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+	desired := r.buildDaemonSet(namespace)
+	if err := r.Create(ctx, desired); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		existing := &appsv1.DaemonSet{}
+		if err := r.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, existing); err != nil {
+			return err
+		}
+		patch := client.MergeFrom(existing.DeepCopy())
+		existing.Spec = desired.Spec
+		return r.Patch(ctx, existing, patch)
 	}
 	return nil
 }

--- a/internal/controller/nodelabeler_daemonset_controller_test.go
+++ b/internal/controller/nodelabeler_daemonset_controller_test.go
@@ -118,6 +118,26 @@ var _ = Describe("NodeLabelerDaemonSet Controller", func() {
 		Expect(dsList.Items).To(HaveLen(1))
 	})
 
+	It("should update the DaemonSet image when the operator restarts with a new image", func() {
+		r := &NodeLabelerDaemonSetReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+
+		By("simulating the first operator startup with v0.0.1")
+		Expect(os.Setenv("NODE_LABELER_IMAGE", "quay.io/kairos/operator-node-labeler:v0.0.1")).To(Succeed())
+		Expect(r.ensureDaemonSetOnStartup(ctx, namespace)).To(Succeed())
+
+		By("simulating an operator upgrade: restart with v0.0.2")
+		Expect(os.Setenv("NODE_LABELER_IMAGE", "quay.io/kairos/operator-node-labeler:v0.0.2")).To(Succeed())
+		Expect(r.ensureDaemonSetOnStartup(ctx, namespace)).To(Succeed())
+
+		By("verifying the DaemonSet now uses the new image")
+		ds := &appsv1.DaemonSet{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, ds)).To(Succeed())
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("quay.io/kairos/operator-node-labeler:v0.0.2"))
+	})
+
 	It("should recreate the DaemonSet if it is deleted", func() {
 		By("creating the DaemonSet via reconciliation")
 		Expect(reconcileOnce(ctx)).To(Succeed())

--- a/internal/controller/nodelabeler_daemonset_controller_test.go
+++ b/internal/controller/nodelabeler_daemonset_controller_test.go
@@ -1,0 +1,141 @@
+package controller
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("NodeLabelerDaemonSet Controller", func() {
+	var (
+		ctx       context.Context
+		namespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "default"
+		Expect(os.Setenv("CONTROLLER_POD_NAMESPACE", namespace)).To(Succeed())
+		Expect(os.Setenv("NODE_LABELER_IMAGE", "quay.io/kairos/operator-node-labeler:v0.0.1")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(os.Unsetenv("CONTROLLER_POD_NAMESPACE")).To(Succeed())
+		Expect(os.Unsetenv("NODE_LABELER_IMAGE")).To(Succeed())
+
+		ds := &appsv1.DaemonSet{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, ds)
+		if err == nil {
+			Expect(k8sClient.Delete(ctx, ds)).To(Succeed())
+		}
+	})
+
+	reconcileOnce := func(ctx context.Context) error {
+		r := &NodeLabelerDaemonSetReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+		_, err := r.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      kairosNodeLabelerDaemonSetName,
+				Namespace: namespace,
+			},
+		})
+		return err
+	}
+
+	It("should create a DaemonSet targeting Kairos nodes", func() {
+		By("reconciling")
+		Expect(reconcileOnce(ctx)).To(Succeed())
+
+		By("verifying the DaemonSet was created")
+		ds := &appsv1.DaemonSet{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, ds)).To(Succeed())
+
+		By("verifying the node selector targets only Kairos nodes")
+		Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("kairos.io/managed", "true"))
+
+		By("verifying it tolerates all taints")
+		Expect(ds.Spec.Template.Spec.Tolerations).To(ContainElement(corev1.Toleration{
+			Operator: corev1.TolerationOpExists,
+		}))
+
+		By("verifying the container spec")
+		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
+		container := ds.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("node-labeler"))
+		Expect(container.Image).To(Equal("quay.io/kairos/operator-node-labeler:v0.0.1"))
+		Expect(container.ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+
+		By("verifying the labeler runs in loop mode")
+		Expect(container.Args).To(ContainElements("--every", "60"))
+
+		By("verifying the NODE_NAME env var is injected from the pod spec")
+		Expect(container.Env).To(ContainElement(corev1.EnvVar{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					APIVersion: "v1",
+					FieldPath:  "spec.nodeName",
+				},
+			},
+		}))
+
+		By("verifying the security context")
+		Expect(container.SecurityContext).NotTo(BeNil())
+		Expect(*container.SecurityContext.RunAsNonRoot).To(BeTrue())
+		Expect(*container.SecurityContext.RunAsUser).To(Equal(int64(1000)))
+
+		By("verifying the host /etc volume mount")
+		Expect(container.VolumeMounts).To(HaveLen(1))
+		Expect(container.VolumeMounts[0].Name).To(Equal("host-etc"))
+		Expect(container.VolumeMounts[0].MountPath).To(Equal("/host/etc"))
+		Expect(container.VolumeMounts[0].ReadOnly).To(BeTrue())
+
+		By("verifying the host /etc volume")
+		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(1))
+		Expect(ds.Spec.Template.Spec.Volumes[0].Name).To(Equal("host-etc"))
+		Expect(ds.Spec.Template.Spec.Volumes[0].HostPath.Path).To(Equal("/etc"))
+	})
+
+	It("should not create a duplicate DaemonSet on subsequent reconciliations", func() {
+		Expect(reconcileOnce(ctx)).To(Succeed())
+		Expect(reconcileOnce(ctx)).To(Succeed())
+
+		dsList := &appsv1.DaemonSetList{}
+		Expect(k8sClient.List(ctx, dsList,
+			client.InNamespace(namespace),
+			client.MatchingLabels(map[string]string{"app": "kairos-node-labeler"}),
+		)).To(Succeed())
+		Expect(dsList.Items).To(HaveLen(1))
+	})
+
+	It("should recreate the DaemonSet if it is deleted", func() {
+		By("creating the DaemonSet via reconciliation")
+		Expect(reconcileOnce(ctx)).To(Succeed())
+
+		By("deleting the DaemonSet")
+		ds := &appsv1.DaemonSet{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, ds)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, ds)).To(Succeed())
+
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, &appsv1.DaemonSet{})
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+
+		By("reconciling again")
+		Expect(reconcileOnce(ctx)).To(Succeed())
+
+		By("verifying the DaemonSet was recreated")
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: kairosNodeLabelerDaemonSetName, Namespace: namespace}, &appsv1.DaemonSet{})).To(Succeed())
+	})
+})

--- a/test/e2e/node_labeler_test.go
+++ b/test/e2e/node_labeler_test.go
@@ -160,6 +160,11 @@ var _ = Describe("Node Labeler E2E", func() {
 			return false
 		}, 3*time.Minute, 5*time.Second).Should(BeTrue(), "DaemonSet pod should be running on the Kairos node")
 
+		By("verifying the cluster has exactly 2 nodes so the pod-count check below is meaningful")
+		nodeList, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeList.Items).To(HaveLen(2), "test requires a 2-node cluster (1 Kairos, 1 non-Kairos)")
+
 		By("verifying the DaemonSet pod runs only on the Kairos node")
 		cmd := exec.Command("docker", "exec", kairosNode, "hostname")
 		out, err := cmd.CombinedOutput()
@@ -170,9 +175,7 @@ var _ = Describe("Node Labeler E2E", func() {
 			LabelSelector: "app=kairos-node-labeler,mode=daemon",
 		})
 		Expect(err).NotTo(HaveOccurred())
-		for _, pod := range pods.Items {
-			Expect(pod.Spec.NodeName).To(Equal(kairosNodeName),
-				"DaemonSet pods must only run on Kairos nodes")
-		}
+		Expect(pods.Items).To(HaveLen(1), "exactly one pod expected — one Kairos node out of two")
+		Expect(pods.Items[0].Spec.NodeName).To(Equal(kairosNodeName))
 	})
 })

--- a/test/e2e/node_labeler_test.go
+++ b/test/e2e/node_labeler_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"os/exec"
 	"strings"
@@ -73,6 +74,15 @@ var _ = Describe("Node Labeler E2E", func() {
 		out, err := exec.Command("docker", "exec", kairosNode, "hostname").CombinedOutput()
 		Expect(err).NotTo(HaveOccurred())
 		kairosNodeName := strings.TrimSpace(string(out))
+
+		By("reading original /etc/kairos-release so we can restore it on cleanup")
+		original, err := exec.Command("docker", "exec", kairosNode, "cat", "/etc/kairos-release").CombinedOutput()
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			cmd := exec.Command("docker", "exec", "-i", kairosNode, "tee", "/etc/kairos-release")
+			cmd.Stdin = bytes.NewReader(original)
+			Expect(cmd.Run()).To(Succeed())
+		})
 
 		By("waiting for the DaemonSet labeler pod to be running on the Kairos node")
 		Eventually(func() bool {

--- a/test/e2e/node_labeler_test.go
+++ b/test/e2e/node_labeler_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // dot-imports are standard for ginkgo tests
 	. "github.com/onsi/gomega"    //nolint:revive // dot-imports are standard for ginkgo tests
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,5 +66,54 @@ var _ = Describe("Node Labeler E2E", func() {
 		}
 		Expect(labeled).To(Equal(1))
 		Expect(unlabeled).To(Equal(1))
+	})
+
+	It("should create a DaemonSet that runs only on Kairos nodes", func() {
+		By("verifying the DaemonSet exists in the operator namespace")
+		Eventually(func() error {
+			_, err := clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), "kairos-node-labeler", metav1.GetOptions{})
+			return err
+		}, 2*time.Minute, 5*time.Second).Should(Succeed(), "kairos-node-labeler DaemonSet should be created")
+
+		ds, err := clientset.AppsV1().DaemonSets(namespace).Get(context.TODO(), "kairos-node-labeler", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the DaemonSet targets only Kairos nodes via node selector")
+		Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("kairos.io/managed", "true"))
+
+		By("verifying the DaemonSet runs the labeler in loop mode")
+		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(ds.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--every"))
+
+		By("waiting for the DaemonSet pod to be running on the Kairos node")
+		Eventually(func() bool {
+			pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "app=kairos-node-labeler,mode=daemon",
+			})
+			if err != nil || len(pods.Items) == 0 {
+				return false
+			}
+			for _, pod := range pods.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					return true
+				}
+			}
+			return false
+		}, 3*time.Minute, 5*time.Second).Should(BeTrue(), "DaemonSet pod should be running on the Kairos node")
+
+		By("verifying the DaemonSet pod runs only on the Kairos node")
+		cmd := exec.Command("docker", "exec", kairosNode, "hostname")
+		out, err := cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred())
+		kairosNodeName := strings.TrimSpace(string(out))
+
+		pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "app=kairos-node-labeler,mode=daemon",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		for _, pod := range pods.Items {
+			Expect(pod.Spec.NodeName).To(Equal(kairosNodeName),
+				"DaemonSet pods must only run on Kairos nodes")
+		}
 	})
 })

--- a/test/e2e/node_labeler_test.go
+++ b/test/e2e/node_labeler_test.go
@@ -68,6 +68,55 @@ var _ = Describe("Node Labeler E2E", func() {
 		Expect(unlabeled).To(Equal(1))
 	})
 
+	It("should update node labels when /etc/kairos-release changes", func() {
+		By("getting the kairos node name")
+		out, err := exec.Command("docker", "exec", kairosNode, "hostname").CombinedOutput()
+		Expect(err).NotTo(HaveOccurred())
+		kairosNodeName := strings.TrimSpace(string(out))
+
+		By("waiting for the DaemonSet labeler pod to be running on the Kairos node")
+		Eventually(func() bool {
+			pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: "app=kairos-node-labeler,mode=daemon",
+				FieldSelector: "spec.nodeName=" + kairosNodeName,
+			})
+			if err != nil || len(pods.Items) == 0 {
+				return false
+			}
+			return pods.Items[0].Status.Phase == corev1.PodRunning
+		}, 3*time.Minute, 5*time.Second).Should(BeTrue(), "DaemonSet pod should be running on the Kairos node")
+
+		By("writing a structured kairos-release with KAIROS_FLAVOR=ubuntu")
+		cmd := exec.Command("docker", "exec", kairosNode, "bash", "-c",
+			`printf 'KAIROS_FLAVOR="ubuntu"\nKAIROS_VARIANT="core"\nKAIROS_RELEASE="v4.0.3"\n' > /etc/kairos-release`)
+		out, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), string(out))
+
+		By("waiting for kairos.io/flavor=ubuntu to appear on the node")
+		Eventually(func() string {
+			node, err := clientset.CoreV1().Nodes().Get(context.TODO(), kairosNodeName, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return node.Labels["kairos.io/flavor"]
+		}, 2*time.Minute, 5*time.Second).Should(Equal("ubuntu"))
+
+		By("changing KAIROS_FLAVOR to alpine in /etc/kairos-release")
+		cmd = exec.Command("docker", "exec", kairosNode, "sed", "-i",
+			`s/KAIROS_FLAVOR="ubuntu"/KAIROS_FLAVOR="alpine"/`, "/etc/kairos-release")
+		out, err = cmd.CombinedOutput()
+		Expect(err).NotTo(HaveOccurred(), string(out))
+
+		By("waiting for kairos.io/flavor to update to alpine")
+		Eventually(func() string {
+			node, err := clientset.CoreV1().Nodes().Get(context.TODO(), kairosNodeName, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return node.Labels["kairos.io/flavor"]
+		}, 2*time.Minute, 5*time.Second).Should(Equal("alpine"))
+	})
+
 	It("should create a DaemonSet that runs only on Kairos nodes", func() {
 		By("verifying the DaemonSet exists in the operator namespace")
 		Eventually(func() error {


### PR DESCRIPTION
using the values in kairos-release. This is preparation work to be able to run it as a DaemonSet too.

See more here:

https://github.com/kairos-io/kairos/issues/3971#issuecomment-4281056270

make sure we don't run the **Job** in a loop (that's an one-off)

Implement the daemonset reconciler

that creates the labeler daemonset to keep label synced with the node