### PR TITLE
Allow insecure registries

### DIFF
--- a/api/v1alpha2/osartifact_types.go
+++ b/api/v1alpha2/osartifact_types.go
@@ -97,7 +97,7 @@ type ImageSpec struct {
 	// +optional
 	CACertificatesVolume string `json:"caCertificatesVolume,omitempty"`
 
-	// PullInsecureRegistry disables TLS verification when pulling the base image during the OCI build step (buildah bud --tls-verify=false). Use for HTTP-only or self-signed-cert base image registries. Only used when building (Ref empty).
+	// PullInsecureRegistry allows pulling images from registries over plain HTTP or with untrusted/self-signed TLS certificates. It applies wherever the operator pulls an image: the buildah base-image pull during the OCI build step (buildah bud --tls-verify=false), and the auroraboot unpack of a pre-built image.ref and of artifacts.bundles (auroraboot unpack --allow-insecure-registries). Use for HTTP-only or self-signed-cert registries, for example a local or in-cluster registry.
 	// +optional
 	PullInsecureRegistry bool `json:"pullInsecureRegistry,omitempty"`
 

--- a/internal/controller/job.go
+++ b/internal/controller/job.go
@@ -57,10 +57,13 @@ func bashCxeCommand() []string {
 	return []string{"/bin/bash", "-cxe"}
 }
 
-func unpackContainer(id, containerImage, pullImage, arch string) corev1.Container {
+func unpackContainer(id, containerImage, pullImage, arch string, insecure bool) corev1.Container {
 	cmd := aurorabootUnpackCmd
 	if arch != "" {
 		cmd = fmt.Sprintf("%s --arch %s", cmd, arch)
+	}
+	if insecure {
+		cmd = fmt.Sprintf("%s --allow-insecure-registries", cmd)
 	}
 	cmd = fmt.Sprintf("%s %s %s", cmd, pullImage, rootfsMountPath)
 
@@ -255,7 +258,7 @@ func (r *OSArtifactReconciler) newBuilderPod(ctx context.Context, artifact *buil
 			inits = append(inits, imageExtractorContainer(r.ToolImage, arch, artifact.Name))
 		}
 		for i, bundle := range artifacts.Bundles {
-			inits = append(inits, unpackContainer(fmt.Sprint(i), r.ToolImage, bundle, arch))
+			inits = append(inits, unpackContainer(fmt.Sprint(i), r.ToolImage, bundle, arch, artifact.Spec.Image.PullInsecureRegistry))
 		}
 		if artifacts.OSRelease != "" {
 			inits = append(inits, osReleaseContainer(r.ToolImage))

--- a/internal/controller/job.go
+++ b/internal/controller/job.go
@@ -89,6 +89,9 @@ func unpackAndPackToArtifactsContainer(artifact *buildv1alpha2.OSArtifact, toolI
 	if arch != "" {
 		unpackCmd = fmt.Sprintf("%s --arch %s", unpackCmd, arch)
 	}
+	if artifact.Spec.Image.PullInsecureRegistry {
+		unpackCmd = fmt.Sprintf("%s --allow-insecure-registries", unpackCmd)
+	}
 	unpackCmd = fmt.Sprintf("%s %s %s", unpackCmd, artifact.Spec.Image.Ref, rootfsMountPath)
 
 	imageName := builtImageName(artifact)

--- a/internal/controller/job_test.go
+++ b/internal/controller/job_test.go
@@ -516,6 +516,32 @@ var _ = Describe("newBuilderPod scheduling", func() {
 	})
 })
 
+var _ = Describe("unpackAndPackToArtifactsContainer", func() {
+	newRefArtifact := func() *buildv1alpha2.OSArtifact {
+		return &buildv1alpha2.OSArtifact{
+			ObjectMeta: metav1.ObjectMeta{Name: "ref-artifact"},
+			Spec: buildv1alpha2.OSArtifactSpec{
+				Image: buildv1alpha2.ImageSpec{Ref: "localhost:5000/my/image:latest"},
+			},
+		}
+	}
+
+	It("does not add --allow-insecure-registries by default", func() {
+		c := unpackAndPackToArtifactsContainer(newRefArtifact(), "auroraboot:test")
+		Expect(c.Args[0]).To(ContainSubstring("auroraboot unpack"))
+		Expect(c.Args[0]).ToNot(ContainSubstring("--allow-insecure-registries"))
+	})
+
+	When("PullInsecureRegistry is true", func() {
+		It("adds --allow-insecure-registries to the unpack command", func() {
+			a := newRefArtifact()
+			a.Spec.Image.PullInsecureRegistry = true
+			c := unpackAndPackToArtifactsContainer(a, "auroraboot:test")
+			Expect(c.Args[0]).To(ContainSubstring("auroraboot unpack --allow-insecure-registries localhost:5000/my/image:latest /rootfs"))
+		})
+	})
+})
+
 var _ = Describe("volumeForExportArtifacts", func() {
 	When("artifacts.volume is set and no PVC exists", func() {
 		It("returns volume named artifacts with source from spec.volumes", func() {

--- a/internal/controller/job_test.go
+++ b/internal/controller/job_test.go
@@ -614,3 +614,16 @@ var _ = Describe("volumeForExportArtifacts", func() {
 		})
 	})
 })
+
+var _ = Describe("unpackContainer", func() {
+	It("does not add --allow-insecure-registries when insecure is false", func() {
+		c := unpackContainer("0", "auroraboot:test", "localhost:5000/bundle:latest", "amd64", false)
+		Expect(c.Args[0]).To(ContainSubstring("auroraboot unpack"))
+		Expect(c.Args[0]).ToNot(ContainSubstring("--allow-insecure-registries"))
+	})
+
+	It("adds --allow-insecure-registries when insecure is true", func() {
+		c := unpackContainer("0", "auroraboot:test", "localhost:5000/bundle:latest", "amd64", true)
+		Expect(c.Args[0]).To(ContainSubstring("auroraboot unpack --arch amd64 --allow-insecure-registries localhost:5000/bundle:latest /rootfs"))
+	})
+})

--- a/internal/controller/osartifact_controller.go
+++ b/internal/controller/osartifact_controller.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	FinalizerName                   = "build.kairos.io/osbuilder-finalizer"
-	CompatibleAurorabootVersion     = "v0.19.3"
+	CompatibleAurorabootVersion     = "v0.24.0"
 	CompatibleBuildahVersion        = "v1.43.1"
 	artifactLabel                   = "build.kairos.io/artifact"
 	artifactExporterIndexAnnotation = "build.kairos.io/export-index"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -153,22 +153,9 @@ func (tc *TestClients) CreateArtifact(artifact *buildv1alpha2.OSArtifact) (strin
 	return artifactName, artifactLabelSelector
 }
 
-// WaitForBuildCompletion waits for the build pod to complete and the artifact to
-// reach a terminal phase (Ready or Error). If the artifact enters Error, the test
-// fails immediately with builder pod and export job logs for diagnostics.
-func (tc *TestClients) WaitForBuildCompletion(artifactName string, artifactLabelSelector labels.Selector) {
-	By("waiting for build pod to complete")
-	Eventually(func(g Gomega) {
-		w, err := tc.Pods.Watch(context.TODO(), metav1.ListOptions{LabelSelector: artifactLabelSelector.String()})
-		g.Expect(err).ToNot(HaveOccurred())
-
-		var stopped bool
-		for !stopped {
-			event, ok := <-w.ResultChan()
-			stopped = event.Type != watch.Deleted && event.Type != watch.Error || !ok
-		}
-	}).WithTimeout(time.Hour).Should(Succeed())
-
+// waitForTerminalPhase waits until the artifact reaches a terminal phase (Ready or Error) and
+// returns it. Shared by WaitForBuildCompletion and WaitForBuildFailure.
+func (tc *TestClients) waitForTerminalPhase(artifactName string) buildv1alpha2.ArtifactPhase {
 	By("waiting for artifact to reach a terminal phase")
 	var terminalPhase buildv1alpha2.ArtifactPhase
 	Eventually(func(g Gomega) {
@@ -192,11 +179,43 @@ func (tc *TestClients) WaitForBuildCompletion(artifactName string, artifactLabel
 		}
 		g.Expect(string(terminalPhase)).ToNot(BeEmpty(), "watch closed without artifact reaching a terminal phase")
 	}).WithTimeout(time.Hour).Should(Succeed())
+	return terminalPhase
+}
 
-	if terminalPhase == buildv1alpha2.Error {
+// WaitForBuildCompletion waits for the build pod to complete and the artifact to
+// reach a terminal phase (Ready or Error). If the artifact enters Error, the test
+// fails immediately with builder pod and export job logs for diagnostics.
+func (tc *TestClients) WaitForBuildCompletion(artifactName string, artifactLabelSelector labels.Selector) {
+	By("waiting for build pod to complete")
+	Eventually(func(g Gomega) {
+		w, err := tc.Pods.Watch(context.TODO(), metav1.ListOptions{LabelSelector: artifactLabelSelector.String()})
+		g.Expect(err).ToNot(HaveOccurred())
+
+		var stopped bool
+		for !stopped {
+			event, ok := <-w.ResultChan()
+			stopped = event.Type != watch.Deleted && event.Type != watch.Error || !ok
+		}
+	}).WithTimeout(time.Hour).Should(Succeed())
+
+	if tc.waitForTerminalPhase(artifactName) == buildv1alpha2.Error {
 		Fail(fmt.Sprintf("artifact %q entered Error phase.\n\n%s",
 			artifactName, tc.collectDebugLogs(artifactLabelSelector)))
 	}
+}
+
+// WaitForBuildFailure waits for the artifact to reach a terminal phase and fails the spec unless
+// that phase is Error. Use to assert a build is expected to fail (e.g. unpacking from an HTTP-only
+// registry without pullInsecureRegistry). Returns the collected debug logs so callers can assert on
+// the failure reason.
+func (tc *TestClients) WaitForBuildFailure(artifactName string, artifactLabelSelector labels.Selector) string {
+	terminalPhase := tc.waitForTerminalPhase(artifactName)
+	logs := tc.collectDebugLogs(artifactLabelSelector)
+	if terminalPhase != buildv1alpha2.Error {
+		Fail(fmt.Sprintf("artifact %q reached %q phase, but it was expected to fail (enter Error phase).\n\n%s",
+			artifactName, terminalPhase, logs))
+	}
+	return logs
 }
 
 // WaitForExportCompletion waits for the export job to complete

--- a/test/e2e/osartifact_examples_test.go
+++ b/test/e2e/osartifact_examples_test.go
@@ -273,6 +273,27 @@ spec:
 	return artifactFromYAML(y)
 }
 
+// pushKairosImageToNoAuthRegistry builds a small kairos image (FROM Hadron with a marker baked in)
+// and pushes it to the no-auth in-cluster registry (HTTP-only). Returns the image ref, the
+// squashfs-relative path of the marker, and the marker content. Used by the insecure-registry
+// tests (image.ref and bundles), which differ only in whether pullInsecureRegistry is set when
+// auroraboot unpacks this HTTP-only image.
+func pushKairosImageToNoAuthRegistry(tc *TestClients, suffix string) (ref, markerRelPath, markerContent string) {
+	repo := "e2e/insecure-" + suffix
+	markerRelPath = "etc/e2e-insecure-marker.txt"
+	markerContent = "insecure-marker"
+
+	ociSpecSecret := createOCISpecSecret("insecure-ocispec-", HadronPreKairosified, "/"+markerRelPath, markerContent)
+	DeferCleanup(func() {
+		_ = clientset.CoreV1().Secrets("default").Delete(context.TODO(), ociSpecSecret.Name, metav1.DeleteOptions{})
+	})
+
+	pushArtifact := ociPushArtifactNoCredentials(suffix, ociSpecSecret.Name, RegistryNoAuthHost, repo)
+	runBuildAndPushOnly(tc, pushArtifact, "insecure-push-"+suffix+"-")
+
+	return RegistryNoAuthHost + "/" + repo + ":latest", markerRelPath, markerContent
+}
+
 // runBuildAndPushOnly creates the artifact and runs build-only (no export phase).
 func runBuildAndPushOnly(tc *TestClients, artifact *buildv1alpha2.OSArtifact, namePrefix string) {
 	artifactName, artifactLabelSelector := createArtifactNoExporters(tc, artifact, namePrefix)
@@ -642,6 +663,135 @@ spec:
       name: %s
 `, suffix, ociSpecForPull.Name, registryCredsSecret.Name))
 			runBuildAndPushOnly(tc, buildArtifact, "buildah-pull-build-"+suffix+"-")
+		})
+	})
+
+	Describe("Insecure registry pull (HTTP image.ref)", func() {
+		// These two specs exercise the auroraboot unpack path for spec.image.ref against the no-auth
+		// in-cluster registry (HTTP-only). They are identical except for pullInsecureRegistry, which
+		// proves the flag is load-bearing: with it the unpack adds --allow-insecure-registries and the
+		// build succeeds; without it auroraboot rejects the plain-HTTP registry and the build errors.
+		// The no-auth registry isolates this to the insecure-pull behavior alone (no credentials).
+
+		It("unpacks image.ref from the HTTP registry when pullInsecureRegistry is set and produces an ISO", func() {
+			suffix := uniqueTestSuffix()
+			ref, markerRelPath, markerContent := pushKairosImageToNoAuthRegistry(tc, suffix)
+
+			// auroraboot unpack runs with --allow-insecure-registries, so the plain-HTTP pull succeeds.
+			// The marker baked into the image must appear in the resulting squashfs, proving the right
+			// image was pulled over HTTP and unpacked.
+			y := fmt.Sprintf(`
+apiVersion: build.kairos.io/v1alpha2
+kind: OSArtifact
+metadata:
+  name: insecure-ref-%s
+  namespace: default
+spec:
+  image:
+    ref: %s
+    pullInsecureRegistry: true
+  artifacts:
+    arch: amd64
+    iso: true
+`, suffix, ref)
+			artifact := artifactFromYAML(y)
+			verifyScript := verifyFilesInSquashfs(map[string]string{markerRelPath: markerContent})
+			artifactName, artifactLabelSelector := createExampleArtifact(tc, artifact, "insecure-ref-"+suffix+"-", verifyScript)
+			runArtifactTest(tc, artifactName, artifactLabelSelector)
+		})
+
+		It("fails to unpack the same HTTP image.ref when pullInsecureRegistry is not set", func() {
+			suffix := uniqueTestSuffix()
+			ref, _, _ := pushKairosImageToNoAuthRegistry(tc, suffix)
+
+			// Same image.ref, same HTTP-only registry, but no pullInsecureRegistry: auroraboot unpack
+			// runs without --allow-insecure-registries, rejects the plain-HTTP registry, and the artifact
+			// enters the Error phase. Asserting the specific message ensures the build fails for this
+			// reason and not, say, a missing image.
+			y := fmt.Sprintf(`
+apiVersion: build.kairos.io/v1alpha2
+kind: OSArtifact
+metadata:
+  name: insecure-ref-noflag-%s
+  namespace: default
+spec:
+  image:
+    ref: %s
+  artifacts:
+    arch: amd64
+    iso: true
+`, suffix, ref)
+			artifact := artifactFromYAML(y)
+			artifactName, artifactLabelSelector := tc.CreateArtifact(artifact)
+			DeferCleanup(func() { tc.Cleanup(artifactName, artifactLabelSelector) })
+			logs := tc.WaitForBuildFailure(artifactName, artifactLabelSelector)
+			Expect(logs).To(ContainSubstring("server gave HTTP response to HTTPS client"),
+				"build should fail because auroraboot rejected the plain-HTTP registry without --allow-insecure-registries")
+		})
+	})
+
+	Describe("Insecure registry pull (HTTP artifacts.bundles)", func() {
+		// Same proof for the artifacts.bundles unpack path, which uses the same auroraboot unpack and
+		// the same pullInsecureRegistry flag. The base image.ref is the public Hadron image (HTTPS), so
+		// the only pull that needs the flag is the HTTP bundle: the flag is therefore what the bundle
+		// unpack depends on.
+
+		It("unpacks a bundle from the HTTP registry when pullInsecureRegistry is set and produces an ISO", func() {
+			suffix := uniqueTestSuffix()
+			bundleRef, markerRelPath, markerContent := pushKairosImageToNoAuthRegistry(tc, suffix)
+
+			// The bundle is unpacked onto /rootfs over plain HTTP thanks to --allow-insecure-registries.
+			// Its marker (absent from the Hadron base) must appear in the squashfs, proving the bundle
+			// was pulled over HTTP and overlaid.
+			y := fmt.Sprintf(`
+apiVersion: build.kairos.io/v1alpha2
+kind: OSArtifact
+metadata:
+  name: insecure-bundle-%s
+  namespace: default
+spec:
+  image:
+    ref: %s
+    pullInsecureRegistry: true
+  artifacts:
+    arch: amd64
+    iso: true
+    bundles:
+      - %s
+`, suffix, HadronPreKairosified, bundleRef)
+			artifact := artifactFromYAML(y)
+			verifyScript := verifyFilesInSquashfs(map[string]string{markerRelPath: markerContent})
+			artifactName, artifactLabelSelector := createExampleArtifact(tc, artifact, "insecure-bundle-"+suffix+"-", verifyScript)
+			runArtifactTest(tc, artifactName, artifactLabelSelector)
+		})
+
+		It("fails to unpack the same HTTP bundle when pullInsecureRegistry is not set", func() {
+			suffix := uniqueTestSuffix()
+			bundleRef, _, _ := pushKairosImageToNoAuthRegistry(tc, suffix)
+
+			// Base (Hadron) unpacks fine over HTTPS, then the HTTP bundle unpack runs without
+			// --allow-insecure-registries, is rejected, and the artifact enters the Error phase.
+			y := fmt.Sprintf(`
+apiVersion: build.kairos.io/v1alpha2
+kind: OSArtifact
+metadata:
+  name: insecure-bundle-noflag-%s
+  namespace: default
+spec:
+  image:
+    ref: %s
+  artifacts:
+    arch: amd64
+    iso: true
+    bundles:
+      - %s
+`, suffix, HadronPreKairosified, bundleRef)
+			artifact := artifactFromYAML(y)
+			artifactName, artifactLabelSelector := tc.CreateArtifact(artifact)
+			DeferCleanup(func() { tc.Cleanup(artifactName, artifactLabelSelector) })
+			logs := tc.WaitForBuildFailure(artifactName, artifactLabelSelector)
+			Expect(logs).To(ContainSubstring("server gave HTTP response to HTTPS client"),
+				"bundle unpack should fail because auroraboot rejected the plain-HTTP registry without --allow-insecure-registries")
 		})
 	})
 


### PR DESCRIPTION
Support insecure registries in the OSArtifact flow

Part of https://github.com/kairos-io/kairos/issues/4081

Passes --allow-insecure-registries to auroraboot unpack when spec.image.pullInsecureRegistry is set, for both the pre-built image.ref and bundles
pulls. Lets the operator pull from local/in-cluster registries over plain HTTP or with self-signed certs (training/workshop use case).

- Reuses the existing pullInsecureRegistry field (no new CRD field).
- Bumps CompatibleAurorabootVersion v0.19.3 -> v0.24.0 (first release with the flag on unpack). Verified no operator-used auroraboot flag was
removed across that range.
- Ginkgo tests cover both paths; full controller suite passes.
