### PR TITLE
feat(nodeop): add UncordonOnFailure to recover cordoned nodes on failure

### DIFF
--- a/api/v1alpha1/nodeop_types.go
+++ b/api/v1alpha1/nodeop_types.go
@@ -51,6 +51,15 @@ type NodeOpSpec struct {
 	// +kubebuilder:default=false
 	Cordon *bool `json:"cordon,omitempty"`
 
+	// UncordonOnFailure specifies whether to uncordon the node if its operation fails.
+	// Only takes effect when Cordon is true, and only uncordons nodes this NodeOp cordoned.
+	// When false (the default), a node whose operation failed stays cordoned so it can be
+	// inspected. Set this to true to have the operator uncordon failed nodes automatically,
+	// which addresses upgrades leaving nodes unschedulable after a failure.
+	// +optional
+	// +kubebuilder:default=false
+	UncordonOnFailure *bool `json:"uncordonOnFailure,omitempty"`
+
 	// DrainOptions specifies the options for draining the node before running the operation.
 	// When enabled, pods will be evicted from the node before the operation starts.
 	// This requires the Cordon field to be true.

--- a/api/v1alpha1/nodeopupgrade_types.go
+++ b/api/v1alpha1/nodeopupgrade_types.go
@@ -66,6 +66,13 @@ type NodeOpUpgradeSpec struct {
 	// producing verbose output to help diagnose upgrade failures.
 	// +optional
 	Debug *bool `json:"debug,omitempty"`
+
+	// UncordonOnFailure specifies whether to uncordon a node if its upgrade fails.
+	// When false (the default), a node whose upgrade failed stays cordoned so it can be
+	// inspected. Set this to true to have the operator uncordon failed nodes automatically.
+	// This value is passed through to the underlying NodeOp.
+	// +optional
+	UncordonOnFailure *bool `json:"uncordonOnFailure,omitempty"`
 }
 
 // NodeOpUpgradeStatus defines the observed state of NodeOpUpgrade.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -137,6 +137,11 @@ func (in *NodeOpSpec) DeepCopyInto(out *NodeOpSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.UncordonOnFailure != nil {
+		in, out := &in.UncordonOnFailure, &out.UncordonOnFailure
+		*out = new(bool)
+		**out = **in
+	}
 	if in.DrainOptions != nil {
 		in, out := &in.DrainOptions, &out.DrainOptions
 		*out = new(DrainOptions)
@@ -291,6 +296,11 @@ func (in *NodeOpUpgradeSpec) DeepCopyInto(out *NodeOpUpgradeSpec) {
 	}
 	if in.Debug != nil {
 		in, out := &in.Debug, &out.Debug
+		*out = new(bool)
+		**out = **in
+	}
+	if in.UncordonOnFailure != nil {
+		in, out := &in.UncordonOnFailure, &out.UncordonOnFailure
 		*out = new(bool)
 		**out = **in
 	}

--- a/config/crd/bases/operator.kairos.io_nodeops.yaml
+++ b/config/crd/bases/operator.kairos.io_nodeops.yaml
@@ -123,6 +123,9 @@ spec:
               stopOnFailure:
                 default: false
                 type: boolean
+              uncordonOnFailure:
+                default: false
+                type: boolean
             required:
             - command
             type: object

--- a/config/crd/bases/operator.kairos.io_nodeopupgrades.yaml
+++ b/config/crd/bases/operator.kairos.io_nodeopupgrades.yaml
@@ -74,6 +74,8 @@ spec:
                 x-kubernetes-map-type: atomic
               stopOnFailure:
                 type: boolean
+              uncordonOnFailure:
+                type: boolean
               upgradeActive:
                 type: boolean
               upgradeRecovery:

--- a/internal/controller/defaults.go
+++ b/internal/controller/defaults.go
@@ -3,9 +3,10 @@ package controller
 // Default values for boolean fields
 const (
 	// NodeOp defaults
-	RebootOnSuccessDefault = false
-	CordonDefault          = false
-	StopOnFailureDefault   = false
+	RebootOnSuccessDefault   = false
+	CordonDefault            = false
+	UncordonOnFailureDefault = false
+	StopOnFailureDefault     = false
 
 	// DrainOptions defaults
 	DrainEnabledDefault            = false

--- a/internal/controller/nodeop_controller.go
+++ b/internal/controller/nodeop_controller.go
@@ -275,12 +275,14 @@ func (r *NodeOpReconciler) cordonNode(ctx context.Context, nodeOp *kairosiov1alp
 // operator did not cordon — including nodes that were already cordoned when
 // the NodeOp started, and nodes manually re-cordoned after the operator
 // uncordoned them once — are left alone.
-func (r *NodeOpReconciler) uncordonNode(ctx context.Context, nodeOp *kairosiov1alpha1.NodeOp, node *corev1.Node) error {
+func (r *NodeOpReconciler) uncordonNode(ctx context.Context, nodeOp *kairosiov1alpha1.NodeOp, nodeName string) error {
 	log := logf.FromContext(ctx)
 
+	// This helper always re-reads the latest node state, so callers only need to
+	// supply the node name rather than a fully-populated Node object.
 	latestNode := &corev1.Node{}
-	if err := r.Get(ctx, types.NamespacedName{Name: node.Name}, latestNode); err != nil {
-		log.Error(err, "Failed to get latest node state", "node", node.Name)
+	if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, latestNode); err != nil {
+		log.Error(err, "Failed to get latest node state", "node", nodeName)
 		return err
 	}
 
@@ -291,7 +293,7 @@ func (r *NodeOpReconciler) uncordonNode(ctx context.Context, nodeOp *kairosiov1a
 		if _, hasAnn := latestNode.Annotations[cordonedByAnnotation]; hasAnn {
 			delete(latestNode.Annotations, cordonedByAnnotation)
 			if err := r.Update(ctx, latestNode); err != nil {
-				log.Error(err, "Failed to clear stale cordoned-by annotation", "node", node.Name)
+				log.Error(err, "Failed to clear stale cordoned-by annotation", "node", nodeName)
 				return err
 			}
 		}
@@ -300,12 +302,12 @@ func (r *NodeOpReconciler) uncordonNode(ctx context.Context, nodeOp *kairosiov1a
 
 	owner, hasAnn := latestNode.Annotations[cordonedByAnnotation]
 	if !hasAnn {
-		log.Info("Node is cordoned but not by this operator; leaving it alone", "node", node.Name)
+		log.Info("Node is cordoned but not by this operator; leaving it alone", "node", nodeName)
 		return nil
 	}
 	if owner != nodeOpOwnerRef(nodeOp) {
 		log.Info("Node was cordoned by a different NodeOp; leaving it alone",
-			"node", node.Name, "cordonedBy", owner, "thisNodeOp", nodeOpOwnerRef(nodeOp))
+			"node", nodeName, "cordonedBy", owner, "thisNodeOp", nodeOpOwnerRef(nodeOp))
 		return nil
 	}
 
@@ -315,11 +317,11 @@ func (r *NodeOpReconciler) uncordonNode(ctx context.Context, nodeOp *kairosiov1a
 	// the node was modified between Get and Update, and the error propagates up
 	// so Reconcile can requeue and re-evaluate.
 	if err := r.Update(ctx, latestNode); err != nil {
-		log.Error(err, "Failed to uncordon node", "node", node.Name)
+		log.Error(err, "Failed to uncordon node", "node", nodeName)
 		return err
 	}
 
-	log.Info("Successfully uncordoned node", "node", node.Name, "nodeOp", nodeOpOwnerRef(nodeOp))
+	log.Info("Successfully uncordoned node", "node", nodeName, "nodeOp", nodeOpOwnerRef(nodeOp))
 	return nil
 }
 
@@ -570,7 +572,7 @@ func (r *NodeOpReconciler) createNodeJob(ctx context.Context, nodeOp *kairosiov1
 			if err := r.drainNode(ctx, &node, nodeOp.Spec.DrainOptions); err != nil {
 				log.Error(err, "Failed to drain node", "node", node.Name)
 				// If draining fails, uncordon the node
-				if uncordonErr := r.uncordonNode(ctx, nodeOp, &node); uncordonErr != nil {
+				if uncordonErr := r.uncordonNode(ctx, nodeOp, node.Name); uncordonErr != nil {
 					log.Error(uncordonErr, "Failed to uncordon node after drain failure", "node", node.Name)
 				}
 				return err
@@ -696,12 +698,7 @@ func (r *NodeOpReconciler) updateNodeOpStatus(ctx context.Context, nodeOp *kairo
 			rebootOnSuccess := getBool(nodeOp.Spec.RebootOnSuccess, RebootOnSuccessDefault)
 
 			if (rebootOnSuccess && status.RebootStatus == rebootStatusCompleted) || !rebootOnSuccess {
-				node := &corev1.Node{}
-				if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
-					log.Error(err, "Failed to get node for uncordoning after reboot completion", "node", nodeName)
-					return err
-				}
-				if err := r.uncordonNode(ctx, nodeOp, node); err != nil {
+				if err := r.uncordonNode(ctx, nodeOp, nodeName); err != nil {
 					log.Error(err, "Failed to uncordon node after reboot completion", "node", nodeName)
 					return err
 				}
@@ -712,17 +709,13 @@ func (r *NodeOpReconciler) updateNodeOpStatus(ctx context.Context, nodeOp *kairo
 		if status.Phase == phaseFailed {
 			anyFailed = true
 
-			// Uncordon the node when the operation failed, if opted in. uncordonNode
-			// only acts on nodes this NodeOp cordoned, so out-of-band cordons are
-			// left alone. Failed jobs do not reboot, so it is safe to uncordon now.
+			// Uncordon the node when the operation failed, if opted in. The
+			// uncordonNode helper only acts on nodes this NodeOp cordoned, so
+			// out-of-band cordons are left alone. Failed jobs do not reboot, so it
+			// is safe to uncordon now.
 			if getBool(nodeOp.Spec.Cordon, CordonDefault) &&
 				getBool(nodeOp.Spec.UncordonOnFailure, UncordonOnFailureDefault) {
-				node := &corev1.Node{}
-				if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
-					log.Error(err, "Failed to get node for uncordoning after job failure", "node", nodeName)
-					return err
-				}
-				if err := r.uncordonNode(ctx, nodeOp, node); err != nil {
+				if err := r.uncordonNode(ctx, nodeOp, nodeName); err != nil {
 					log.Error(err, "Failed to uncordon node after job failure", "node", nodeName)
 					return err
 				}

--- a/internal/controller/nodeop_controller.go
+++ b/internal/controller/nodeop_controller.go
@@ -711,6 +711,22 @@ func (r *NodeOpReconciler) updateNodeOpStatus(ctx context.Context, nodeOp *kairo
 		// Count failed jobs
 		if status.Phase == phaseFailed {
 			anyFailed = true
+
+			// Uncordon the node when the operation failed, if opted in. uncordonNode
+			// only acts on nodes this NodeOp cordoned, so out-of-band cordons are
+			// left alone. Failed jobs do not reboot, so it is safe to uncordon now.
+			if getBool(nodeOp.Spec.Cordon, CordonDefault) &&
+				getBool(nodeOp.Spec.UncordonOnFailure, UncordonOnFailureDefault) {
+				node := &corev1.Node{}
+				if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+					log.Error(err, "Failed to get node for uncordoning after job failure", "node", nodeName)
+					return err
+				}
+				if err := r.uncordonNode(ctx, nodeOp, node); err != nil {
+					log.Error(err, "Failed to uncordon node after job failure", "node", nodeName)
+					return err
+				}
+			}
 		}
 
 		// Count completed nodes based on whether reboot is required

--- a/internal/controller/nodeop_controller_test.go
+++ b/internal/controller/nodeop_controller_test.go
@@ -986,6 +986,205 @@ var _ = Describe("NodeOp Controller", func() {
 				"Node should remain cordoned; a same-name/different-UID NodeOp must not claim a stale annotation")
 		})
 
+		It("should uncordon a node whose job failed when UncordonOnFailure is true", func() {
+			By("Creating a NodeOp with Cordon and UncordonOnFailure enabled")
+			uncordonNodeOp := &kairosiov1alpha1.NodeOp{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kairos.io/v1alpha1",
+					Kind:       "NodeOp",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-uncordon-fail", resourceName),
+					Namespace: "default",
+				},
+				Spec: kairosiov1alpha1.NodeOpSpec{
+					Command:           []string{"echo", "test"},
+					Cordon:            asBool(true),
+					UncordonOnFailure: asBool(true),
+					RebootOnSuccess:   asBool(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, uncordonNodeOp)).To(Succeed())
+			DeferCleanup(func() {
+				Eventually(func() error {
+					return k8sClient.Delete(ctx, uncordonNodeOp)
+				}, timeout, interval).Should(Succeed())
+			})
+
+			controllerReconciler := &NodeOpReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Reconciling to cordon the node and create the Job")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      uncordonNodeOp.Name,
+					Namespace: "default",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the operator cordoned the node")
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			Expect(node.Spec.Unschedulable).To(BeTrue(), "Node should be cordoned by the operator")
+
+			By("Failing the Job")
+			jobList := &batchv1.JobList{}
+			Expect(k8sClient.List(ctx, jobList,
+				client.InNamespace("default"),
+				client.MatchingLabels(map[string]string{"kairos.io/nodeop": uncordonNodeOp.Name}),
+			)).To(Succeed())
+			Expect(jobList.Items).To(HaveLen(1))
+			Expect(markJobAsFailed(ctx, k8sClient, &jobList.Items[0])).To(Succeed())
+
+			By("Reconciling again to process the job failure")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      uncordonNodeOp.Name,
+					Namespace: "default",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the node is uncordoned and the ownership annotation is cleared")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			Expect(node.Spec.Unschedulable).To(BeFalse(), "Node should be uncordoned after job failure")
+			Expect(node.Annotations).NotTo(HaveKey("operator.kairos.io/cordoned-by"))
+		})
+
+		It("should leave a failed node cordoned when UncordonOnFailure is not set", func() {
+			By("Creating a NodeOp with Cordon enabled but UncordonOnFailure unset")
+			stayCordonedNodeOp := &kairosiov1alpha1.NodeOp{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kairos.io/v1alpha1",
+					Kind:       "NodeOp",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-stay-cordoned", resourceName),
+					Namespace: "default",
+				},
+				Spec: kairosiov1alpha1.NodeOpSpec{
+					Command:         []string{"echo", "test"},
+					Cordon:          asBool(true),
+					RebootOnSuccess: asBool(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, stayCordonedNodeOp)).To(Succeed())
+			DeferCleanup(func() {
+				Eventually(func() error {
+					return k8sClient.Delete(ctx, stayCordonedNodeOp)
+				}, timeout, interval).Should(Succeed())
+			})
+
+			controllerReconciler := &NodeOpReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Reconciling to cordon the node and create the Job")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      stayCordonedNodeOp.Name,
+					Namespace: "default",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Failing the Job")
+			jobList := &batchv1.JobList{}
+			Expect(k8sClient.List(ctx, jobList,
+				client.InNamespace("default"),
+				client.MatchingLabels(map[string]string{"kairos.io/nodeop": stayCordonedNodeOp.Name}),
+			)).To(Succeed())
+			Expect(jobList.Items).To(HaveLen(1))
+			Expect(markJobAsFailed(ctx, k8sClient, &jobList.Items[0])).To(Succeed())
+
+			By("Reconciling again to process the job failure")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      stayCordonedNodeOp.Name,
+					Namespace: "default",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the node remains cordoned")
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			Expect(node.Spec.Unschedulable).To(BeTrue(), "Node should remain cordoned when UncordonOnFailure is not set")
+		})
+
+		It("should not uncordon a failed node cordoned out-of-band even when UncordonOnFailure is true", func() {
+			By("Manually cordoning the node before any NodeOp activity (no ownership annotation)")
+			node := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			node.Spec.Unschedulable = true
+			Expect(k8sClient.Update(ctx, node)).To(Succeed())
+
+			By("Creating a NodeOp with Cordon and UncordonOnFailure enabled")
+			outOfBandNodeOp := &kairosiov1alpha1.NodeOp{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kairos.io/v1alpha1",
+					Kind:       "NodeOp",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-outofband", resourceName),
+					Namespace: "default",
+				},
+				Spec: kairosiov1alpha1.NodeOpSpec{
+					Command:           []string{"echo", "test"},
+					Cordon:            asBool(true),
+					UncordonOnFailure: asBool(true),
+					RebootOnSuccess:   asBool(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, outOfBandNodeOp)).To(Succeed())
+			DeferCleanup(func() {
+				Eventually(func() error {
+					return k8sClient.Delete(ctx, outOfBandNodeOp)
+				}, timeout, interval).Should(Succeed())
+			})
+
+			controllerReconciler := &NodeOpReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Reconciling to create the Job (node already cordoned, so cordonNode does not claim ownership)")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      outOfBandNodeOp.Name,
+					Namespace: "default",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Failing the Job")
+			jobList := &batchv1.JobList{}
+			Expect(k8sClient.List(ctx, jobList,
+				client.InNamespace("default"),
+				client.MatchingLabels(map[string]string{"kairos.io/nodeop": outOfBandNodeOp.Name}),
+			)).To(Succeed())
+			Expect(jobList.Items).To(HaveLen(1))
+			Expect(markJobAsFailed(ctx, k8sClient, &jobList.Items[0])).To(Succeed())
+
+			By("Reconciling again to process the job failure")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      outOfBandNodeOp.Name,
+					Namespace: "default",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the node remains cordoned because the operator did not cordon it")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, node)).To(Succeed())
+			Expect(node.Spec.Unschedulable).To(BeTrue(),
+				"Node cordoned out-of-band must not be uncordoned by UncordonOnFailure")
+		})
+
 		It("should create a reboot pod when RebootOnSuccess is true and job completes successfully", func() {
 			By("Creating a NodeOp with RebootOnSuccess=true")
 			rebootNodeOp := &kairosiov1alpha1.NodeOp{

--- a/internal/controller/nodeopupgrade_controller.go
+++ b/internal/controller/nodeopupgrade_controller.go
@@ -121,15 +121,16 @@ func (r *NodeOpUpgradeReconciler) createNodeOp(ctx context.Context,
 			},
 		},
 		Spec: kairosiov1alpha1.NodeOpSpec{
-			NodeSelector:     nodeOpUpgrade.Spec.NodeSelector,
-			Image:            nodeOpUpgrade.Spec.Image,
-			ImagePullSecrets: nodeOpUpgrade.Spec.ImagePullSecrets,
-			Concurrency:      nodeOpUpgrade.Spec.Concurrency,
-			StopOnFailure:    nodeOpUpgrade.Spec.StopOnFailure,
-			Command:          upgradeCommand,
-			HostMountPath:    hostMountPath,
-			Cordon:           asBool(true), // Always cordon for upgrades
-			RebootOnSuccess:  &shouldReboot,
+			NodeSelector:      nodeOpUpgrade.Spec.NodeSelector,
+			Image:             nodeOpUpgrade.Spec.Image,
+			ImagePullSecrets:  nodeOpUpgrade.Spec.ImagePullSecrets,
+			Concurrency:       nodeOpUpgrade.Spec.Concurrency,
+			StopOnFailure:     nodeOpUpgrade.Spec.StopOnFailure,
+			Command:           upgradeCommand,
+			HostMountPath:     hostMountPath,
+			Cordon:            asBool(true), // Always cordon for upgrades
+			UncordonOnFailure: nodeOpUpgrade.Spec.UncordonOnFailure,
+			RebootOnSuccess:   &shouldReboot,
 			DrainOptions: &kairosiov1alpha1.DrainOptions{
 				Enabled: asBool(true), // Always drain for upgrades
 			},

--- a/internal/controller/nodeopupgrade_controller_test.go
+++ b/internal/controller/nodeopupgrade_controller_test.go
@@ -350,6 +350,46 @@ var _ = Describe("NodeOpUpgrade Controller", func() {
 			Expect(nodeOp.Spec.NodeSelector).To(Equal(nodeOpUpgradeWithSecrets.Spec.NodeSelector))
 		})
 
+		It("should pass UncordonOnFailure from NodeOpUpgrade to created NodeOp", func() {
+			By("Creating a NodeOpUpgrade with UncordonOnFailure enabled")
+			nodeOpUpgradeWithUncordon := &kairosiov1alpha1.NodeOpUpgrade{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-uncordon", nodeOpUpgradeName),
+					Namespace: "default",
+				},
+				Spec: kairosiov1alpha1.NodeOpUpgradeSpec{
+					Image:             "quay.io/kairos/opensuse:leap-15.6-standard-amd64-generic-v3.4.2-k3sv1.30.11-k3s1",
+					UncordonOnFailure: asBool(true),
+				},
+			}
+			Expect(k8sClient.Create(ctx, nodeOpUpgradeWithUncordon)).To(Succeed())
+			DeferCleanup(func() {
+				Eventually(func() error {
+					return k8sClient.Delete(ctx, nodeOpUpgradeWithUncordon)
+				}, timeout, interval).Should(Succeed())
+			})
+
+			By("Reconciling the created NodeOpUpgrade")
+			nodeOp, err := reconcileNodeOpUpgrade(ctx, k8sClient, nodeOpUpgradeWithUncordon.Name)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the NodeOp carries the same UncordonOnFailure value")
+			Expect(nodeOp.Spec.UncordonOnFailure).NotTo(BeNil())
+			Expect(*nodeOp.Spec.UncordonOnFailure).To(BeTrue())
+		})
+
+		It("should default UncordonOnFailure to false on the NodeOp when not set on the NodeOpUpgrade", func() {
+			By("Creating a NodeOpUpgrade without UncordonOnFailure")
+			Expect(k8sClient.Create(ctx, nodeOpUpgrade)).To(Succeed())
+
+			By("Reconciling the created NodeOpUpgrade")
+			nodeOp, err := reconcileNodeOpUpgrade(ctx, k8sClient, nodeOpUpgradeName)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the NodeOp resolves UncordonOnFailure to false (preserving the safe default)")
+			Expect(getBool(nodeOp.Spec.UncordonOnFailure, UncordonOnFailureDefault)).To(BeFalse())
+		})
+
 		It("should generate correct upgrade command for active partition only", func() {
 			By("Creating the NodeOpUpgrade resource with active upgrade only")
 			nodeOpUpgrade.Spec.UpgradeActive = asBool(true)


### PR DESCRIPTION
Add an opt-in UncordonOnFailure field to NodeOpSpec (default false). When true and the node was cordoned by this NodeOp, the operator uncordons the node after its job fails, instead of leaving it unschedulable. Reuses the ownership-aware uncordonNode helper so nodes cordoned out-of-band are left alone.

NodeOpUpgrade exposes the same field and passes it through to the NodeOp it creates, keeping one consistent default (false) across both resources.

Addresses the second takeaway from kairos-io/kairos#4108.