### PR TITLE
feat(build): add BuildOptions.KairosInitImage to override the kairos-init ref

### DIFF
--- a/api/v1alpha2/osartifact_types.go
+++ b/api/v1alpha2/osartifact_types.go
@@ -129,6 +129,14 @@ type BuildOptions struct {
 
 	// FIPS enables FIPS mode.
 	FIPS bool `json:"fips,omitempty"`
+
+	// KairosInitImage overrides the container image used for the kairos-init
+	// build stage. When empty, the built-in default is used
+	// (quay.io/kairos/kairos-init:<default-tag>). Setting this lets an
+	// operator pin the exact kairos-init image tag or replace the ref
+	// entirely (for example, an air-gapped mirror).
+	// +optional
+	KairosInitImage string `json:"kairosInitImage,omitempty"`
 }
 
 // OCISpec describes building with a custom OCI build definition (Stage 1).

--- a/config/crd/bases/build.kairos.io_osartifacts.yaml
+++ b/config/crd/bases/build.kairos.io_osartifacts.yaml
@@ -4556,6 +4556,8 @@ spec:
                         type: string
                       fips:
                         type: boolean
+                      kairosInitImage:
+                        type: string
                       kubernetesDistro:
                         type: string
                       kubernetesVersion:

--- a/internal/controller/default_ocispec.go
+++ b/internal/controller/default_ocispec.go
@@ -25,11 +25,15 @@ package controller
 
 // DefaultOCISpecBaseImageSection is injected at the top when buildOptions is set.
 // BASE_IMAGE has no default; validation requires buildOptions.baseImage when buildOptions is set.
+// KAIROS_INIT_IMAGE defaults to quay.io/kairos/kairos-init:${KAIROS_INIT} so
+// existing users who set only KAIROS_INIT keep working, and callers that want
+// to swap the whole ref (e.g. an air-gapped mirror) set KAIROS_INIT_IMAGE.
 const DefaultOCISpecBaseImageSection = `# base image section
 ARG BASE_IMAGE
 ARG KAIROS_INIT=v0.7.0
+ARG KAIROS_INIT_IMAGE=quay.io/kairos/kairos-init:${KAIROS_INIT}
 
-FROM quay.io/kairos/kairos-init:${KAIROS_INIT} AS kairos-init
+FROM ${KAIROS_INIT_IMAGE} AS kairos-init
 
 FROM ${BASE_IMAGE} AS base-kairos
 ARG MODEL=generic

--- a/internal/controller/job.go
+++ b/internal/controller/job.go
@@ -713,6 +713,7 @@ func ociBuildArgPairs(artifact *buildv1alpha2.OSArtifact) []string {
 	addPair("MODEL", opts.Model)
 	addPair("KUBERNETES_DISTRO", opts.KubernetesDistro)
 	addPair("KUBERNETES_VERSION", opts.KubernetesVersion)
+	addPair("KAIROS_INIT_IMAGE", opts.KairosInitImage)
 	if opts.TrustedBoot {
 		addPair("TRUSTED_BOOT", "true")
 	}

--- a/internal/controller/job_test.go
+++ b/internal/controller/job_test.go
@@ -119,6 +119,19 @@ var _ = Describe("buildahBuildContainer", func() {
 		It("omits --build-arg for empty options", func() {
 			c := buildahBuildContainer(artifact, "", "", testBuildahImage)
 			Expect(c.Args[0]).ToNot(ContainSubstring("KUBERNETES_VERSION"))
+			Expect(c.Args[0]).ToNot(ContainSubstring("KAIROS_INIT_IMAGE"))
+		})
+	})
+
+	When("BuildOptions.KairosInitImage is set", func() {
+		It("adds --build-arg KAIROS_INIT_IMAGE=<ref>", func() {
+			artifact.Spec.Image.BuildOptions = &buildv1alpha2.BuildOptions{
+				Version:         "v3.6.0",
+				BaseImage:       "ubuntu:22.04",
+				KairosInitImage: "mirror.example/kairos/kairos-init:v0.8.0",
+			}
+			c := buildahBuildContainer(artifact, "", "", testBuildahImage)
+			Expect(c.Args[0]).To(ContainSubstring("--build-arg KAIROS_INIT_IMAGE=mirror.example/kairos/kairos-init:v0.8.0"))
 		})
 	})
 


### PR DESCRIPTION
The default OCI build template hardcoded quay.io/kairos/kairos-init as the base for the kairos-init stage. Callers that want to pin the full ref (for example, an air-gapped mirror or a specific SHA) had to fall back to the OCISpec advanced mode and write their own Dockerfile.

Add a KairosInitImage field on BuildOptions and a KAIROS_INIT_IMAGE build ARG on the default Dockerfile template. The new ARG defaults to quay.io/kairos/kairos-init:${KAIROS_INIT}, so existing users pinning only KAIROS_INIT (the tag) are unaffected; callers that want to swap the whole ref set KAIROS_INIT_IMAGE.

The field lives on BuildOptions rather than ImageSpec so it only surfaces on the build path where kairos-init actually runs; the pre-built Ref path and OCISpec-only path do not use it.


This feature is needed in this PR: https://github.com/kairos-io/AuroraBoot/pull/615/changes so that when the "operator" backend is used, the Kairos init image option from the web UI can still be respected (by passing it down through the OSArtifact).