### PR TITLE
fix: netboot reuse iso name

### DIFF
--- a/api/v1alpha2/osartifact_types.go
+++ b/api/v1alpha2/osartifact_types.go
@@ -282,36 +282,35 @@ type OSArtifactSpec struct {
 }
 
 type NameOverrideSpec struct {
+	// ISO overrides the ISO artifact name. This field is also used as the baseName for netboot artifacts.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	// +optional
 	ISO string `json:"iso,omitempty"`
 
+	// CloudImage overrides the cloud image artifact name.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	// +optional
 	CloudImage string `json:"cloudImage,omitempty"`
 
+	// AzureImage overrides the Azure image artifact name.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	// +optional
 	AzureImage string `json:"azureImage,omitempty"`
 
+	// GCEImage overrides the GCE image artifact name.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	// +optional
 	GCEImage string `json:"gceImage,omitempty"`
 
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
-	// +optional
-	Netboot string `json:"netboot,omitempty"`
-
+	// UKI overrides the UKI artifact name.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
@@ -545,10 +544,6 @@ func (s *OSArtifact) ArtifactNameFor(kind OSArtifactKind) string {
 	case OSArtifactKindGCE:
 		if s.Spec.NameOverride.GCEImage != "" {
 			return s.Spec.NameOverride.GCEImage
-		}
-	case OSArtifactKindNetboot:
-		if s.Spec.NameOverride.Netboot != "" {
-			return s.Spec.NameOverride.Netboot
 		}
 	case OSArtifactKindUKI:
 		if s.Spec.NameOverride.UKI != "" {

--- a/api/v1alpha2/osartifact_types_test.go
+++ b/api/v1alpha2/osartifact_types_test.go
@@ -487,18 +487,6 @@ var _ = Describe("OSArtifact.ArtifactNameFor", func() {
 			Expect(artifact.ArtifactNameFor("gce")).To(Equal(nameOverride))
 		})
 
-		It("returns nameOverride.Netboot for kind 'netboot'", func() {
-			artifact := &v1alpha2.OSArtifact{
-				Spec: v1alpha2.OSArtifactSpec{
-					NameOverride: v1alpha2.NameOverrideSpec{
-						Netboot: nameOverride,
-					},
-				},
-			}
-			artifact.Name = defaultName
-			Expect(artifact.ArtifactNameFor("netboot")).To(Equal(nameOverride))
-		})
-
 		It("returns nameOverride.UKI for kind 'uki'", func() {
 			artifact := &v1alpha2.OSArtifact{
 				Spec: v1alpha2.OSArtifactSpec{
@@ -509,6 +497,14 @@ var _ = Describe("OSArtifact.ArtifactNameFor", func() {
 			}
 			artifact.Name = defaultName
 			Expect(artifact.ArtifactNameFor("uki")).To(Equal(nameOverride))
+		})
+
+		It("returns metadata.name for kind 'netboot' (no override field)", func() {
+			artifact := &v1alpha2.OSArtifact{
+				Spec: v1alpha2.OSArtifactSpec{},
+			}
+			artifact.Name = defaultName
+			Expect(artifact.ArtifactNameFor("netboot")).To(Equal(defaultName))
 		})
 
 		It("falls back to the resource name for unmatched kinds", func() {

--- a/config/crd/bases/build.kairos.io_osartifacts.yaml
+++ b/config/crd/bases/build.kairos.io_osartifacts.yaml
@@ -5364,11 +5364,6 @@ spec:
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
-                  netboot:
-                    maxLength: 253
-                    minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
                   uki:
                     maxLength: 253
                     minLength: 1

--- a/internal/controller/job.go
+++ b/internal/controller/job.go
@@ -515,7 +515,7 @@ func makeCloudImageContainer(toolImage string, artifact *buildv1alpha2.OSArtifac
 
 // isoBasenameForNetboot returns the ISO basename (without .iso) so netboot finds the right file: use UKI name when the ISO was built by build-uki.
 func isoBasenameForNetboot(artifact *buildv1alpha2.OSArtifact, artifacts *buildv1alpha2.ArtifactSpec) string {
-	artifactName := artifact.ArtifactNameFor(buildv1alpha2.OSArtifactKindNetboot)
+	artifactName := artifact.ArtifactNameFor(buildv1alpha2.OSArtifactKindISO)
 	if artifacts != nil && artifacts.UKI != nil && artifacts.UKI.ISO {
 		return ukiArtifactName(artifactName)
 	}

--- a/test/e2e/osartifact_formats_test.go
+++ b/test/e2e/osartifact_formats_test.go
@@ -284,6 +284,57 @@ var _ = Describe("OSArtifact NameOverride Tests", func() {
 		})
 	})
 
+	Describe("NameOverride with Netboot", func() {
+		It("produces netboot artifacts named after the ISO base name", func() {
+			verifyScript := fmt.Sprintf(`
+				set -e
+				iso_name="%s"
+				# Netboot outputs are named after the ISO artifact basename:
+				#   <name>-kernel  <name>-initrd  <name>.squashfs
+				kernel_file=$(ls /artifacts/${iso_name}-kernel 2>/dev/null | head -n1)
+				if [ -z "$kernel_file" ]; then
+					echo "ERROR: expected ${iso_name}-kernel not found"
+					ls -la /artifacts/ || true
+					exit 1
+				fi
+				initrd_file=$(ls /artifacts/${iso_name}-initrd 2>/dev/null | head -n1)
+				if [ -z "$initrd_file" ]; then
+					echo "ERROR: expected ${iso_name}-initrd not found"
+					exit 1
+				fi
+				squashfs_file=$(ls /artifacts/${iso_name}.squashfs 2>/dev/null | head -n1)
+				if [ -z "$squashfs_file" ]; then
+					echo "ERROR: expected ${iso_name}.squashfs not found"
+					ls -la /artifacts/ || true
+					exit 1
+				fi
+				for file in "$kernel_file" "$initrd_file" "$squashfs_file"; do
+					if [ ! -s "$file" ]; then
+						echo "ERROR: file is empty: $file"
+						exit 1
+					fi
+				done
+				echo "PASS: Netboot artifacts produced with ISO base name: $kernel_file $initrd_file $squashfs_file"
+			`, overrideName)
+
+			spec := buildv1alpha2.OSArtifactSpec{
+				Image: buildv1alpha2.ImageSpec{
+					Ref: HadronPreKairosified,
+				},
+				Artifacts: &buildv1alpha2.ArtifactSpec{
+					ISO:     true,
+					Netboot: true,
+					Arch:    "amd64",
+				},
+				NameOverride: buildv1alpha2.NameOverrideSpec{
+					ISO: overrideName,
+				},
+			}
+			artifactName, artifactLabelSelector := createArtifactWithExporter(tc, "nameoverride-netboot-", spec, verifyScript)
+			runArtifactTest(tc, artifactName, artifactLabelSelector)
+		})
+	})
+
 	Describe("OSArtifact Format Tests", func() {
 		var artifactName string
 		var artifactLabelSelector labels.Selector


### PR DESCRIPTION
Hi guys,

As per Mr. Claude comment [docs(operator): nameOverride for artifacts](https://github.com/kairos-io/kairos-docs/pull/661):
> isoBasenameForNetboot in internal/controller/job.go uses NameOverride.Netboot (falling back to metadata.name) to locate the source ISO fed into auroraboot netboot. But the ISO on disk was written using NameOverride.ISO. So if a user sets:
>```yaml
>nameOverride:
>  iso: foo
>artifacts:
>  iso: true
>  netboot: true
>```
> the ISO lands at /artifacts/foo.iso while the netboot step looks for /artifacts/<metadata.name>.iso and the build fails.
>
> The doc currently implies each override is independent. Options:
> - Add a caveat: "when netboot is enabled, nameOverride.netboot must equal nameOverride.iso."
> - Better: fix in the operator so netboot reuses the ISO name (open a follow-up issue on kairos-operator?). The coupling is invisible from the CRD schema, so I would lean toward fixing it upstream.


`nameOverride` was introduced very recently so I think that we can make change in API without deprecating a field. Since netboot reads iso as input I can't imagine situation where netboot artifact name would differ from ISO name 🤔 If there any - please let me know so I'll update the code accordingly

